### PR TITLE
Force desktop build to use gcc 11.2.0 instead of 12.2.0

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -48,6 +48,12 @@ jobs:
           cache: true
           cache-key-prefix: install-qt-${{ env.QT_VERSION }}-action
 
+      - name: Uninstall GCC 12.2.0
+        run: choco uninstall mingw
+
+      - name: Install GCC 11.2.0
+        run: choco install mingw --version 11.2.0
+
       - name: Set Debug Flags
         if: inputs.build_type == 'Debug'
         run: echo "EXTRA_CMAKE_FLAGS=${{ env.EXTRA_CMAKE_FLAGS }} -DENABLE_DEBUG=True" >> $GITHUB_ENV


### PR DESCRIPTION
This fixes the missing codecvt entry point for now