### PR TITLE
Add 'X' Button to Connected Entrance Tracker Entrances

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -118,6 +118,13 @@ void MainWindow::closeEvent(QCloseEvent *event)
 }
 
 void MainWindow::clear_layout(QLayout* layout) {
+
+    // Recursively clear child layouts
+    for (auto nestedLayout : layout->findChildren<QLayout*>())
+    {
+        clear_layout(nestedLayout);
+    }
+
     while (QLayoutItem* item = layout->takeAt(0))
     {
         if (QWidget* widget = item->widget())

--- a/gui/tracker/tracker.cpp
+++ b/gui/tracker/tracker.cpp
@@ -605,8 +605,26 @@ void MainWindow::update_tracker()
     currentPointSize = 12;
     for (auto& entrance : areaEntrances[currentTrackerArea])
     {
+        // New Horizontal layout to add the label and the disconnect button
+        // if the entrance is connected
+        auto hLayout = new QHBoxLayout();
+
         auto newLabel = new TrackerLabel(TrackerLabelType::EntranceSource, currentPointSize, nullptr, entrance);
-        ui->entrance_scroll_layout->addWidget(newLabel);
+        hLayout->addWidget(newLabel);
+        // If the entrance is connected, give the user a disconnect button
+        if (entrance->getReplaces())
+        {
+            hLayout->setContentsMargins(7, 0, 0, 0);
+            auto disconnectButton = new QPushButton("X");
+            set_font(disconnectButton, "fira_sans", currentPointSize);
+            disconnectButton->setCursor(Qt::PointingHandCursor);
+            disconnectButton->setMaximumWidth(20);
+            disconnectButton->setMaximumHeight(15);
+            connect(disconnectButton, &QPushButton::clicked, this, [&](){MainWindow::tracker_disconnect_entrance(entrance);});
+            hLayout->addWidget(disconnectButton);
+        }
+
+        ui->entrance_scroll_layout->addLayout(hLayout);
         connect(newLabel, &TrackerLabel::entrance_source_label_clicked, this, &MainWindow::tracker_show_available_target_entrances);
         connect(newLabel, &TrackerLabel::entrance_source_label_disconnect, this, &MainWindow::tracker_disconnect_entrance);
         connect(newLabel, &TrackerLabel::mouse_over_entrance_label, this, &MainWindow::tracker_display_current_entrance);


### PR DESCRIPTION
The 'X' button can disconnect the entrance if necessary (in addition to right clicking the entrance)