### PR TITLE
Fix ordering of custom colors to match SD Rando

### DIFF
--- a/customizer/data/Link/metadata.yaml
+++ b/customizer/data/Link/metadata.yaml
@@ -1,28 +1,28 @@
 default_hero_colors:
-  Hair:        FFEF10
-  Skin:        F7DB9C
-  Mouth:       F74963
-  Eyes:        10514A
-  Sclera:      FFFFFF
-  #Hat:        5AB24A
-  Tunic:       5AB24A
-  Undershirt:  ADE342
-  Pants:       FFFFFF
-  Boots:       944908
-  Belt:        633008
-  Belt Buckle: FFEF10
+  - Hair:        FFEF10
+  - Skin:        F7DB9C
+  - Mouth:       F74963
+  - Eyes:        10514A
+  - Sclera:      FFFFFF
+  - #Hat:        5AB24A
+  - Tunic:       5AB24A
+  - Undershirt:  ADE342
+  - Pants:       FFFFFF
+  - Boots:       944908
+  - Belt:        633008
+  - Belt Buckle: FFEF10
   
 default_casual_colors:
-  Hair:         FFEF10
-  Skin:         F7DB9C
-  Mouth:        F74963
-  Eyes:         10514A
-  Sclera:       FFFFFF
-  Shirt:        4A75AD
-  Shirt Emblem: FFFFD6
-  Armbands:     63696B
-  Pants:        FFA608
-  Shoes:        63696B
-  Shoe Soles:   D6BA39
+  - Hair:         FFEF10
+  - Skin:         F7DB9C
+  - Mouth:        F74963
+  - Eyes:         10514A
+  - Sclera:       FFFFFF
+  - Shirt:        4A75AD
+  - Shirt Emblem: FFFFD6
+  - Armbands:     63696B
+  - Pants:        FFA608
+  - Shoes:        63696B
+  - Shoe Soles:   D6BA39
 
 default_casual: false

--- a/customizer/model.cpp
+++ b/customizer/model.cpp
@@ -1,6 +1,5 @@
 #include "model.hpp"
 
-#include <list>
 #include <tuple>
 #include <filesystem>
 
@@ -24,6 +23,8 @@ ModelError CustomModel::loadFromFolder() {
     folder = DATA_PATH "customizer/" + modelName;
     
     presets.clear();
+    heroOrdering.clear();
+    casualOrdering.clear();
 
     std::string metaStr;
     if(Utility::getFileContents(folder / "metadata.yaml", metaStr, true) != 0) {
@@ -38,14 +39,22 @@ ModelError CustomModel::loadFromFolder() {
 
     ColorPreset& defaultPreset = presets.emplace_back();
     for (const auto& presetObject : metaTree["default_hero_colors"]) {
-        const std::string colorName = presetObject.first.as<std::string>();
-        const std::string color = presetObject.second.as<std::string>();
-        defaultPreset.heroColors[colorName] = color;
+        for (const auto& presetColor : presetObject)
+        {
+            const std::string colorName = presetColor.first.as<std::string>();
+            const std::string color = presetColor.second.as<std::string>();
+            defaultPreset.heroColors[colorName] = color;
+            heroOrdering.emplace_back(colorName);
+        }
     }
     for (const auto& presetObject : metaTree["default_casual_colors"]) {
-        const std::string colorName = presetObject.first.as<std::string>();
-        const std::string color = presetObject.second.as<std::string>();
-        defaultPreset.casualColors[colorName] = color;
+        for (const auto& presetColor : presetObject)
+        {
+            const std::string colorName = presetColor.first.as<std::string>();
+            const std::string color = presetColor.second.as<std::string>();
+            defaultPreset.casualColors[colorName] = color;
+            casualOrdering.emplace_back(colorName);
+        }
     }
 
     casual = metaTree["default_casual"].as<bool>();
@@ -105,6 +114,15 @@ const ColorMap_t& CustomModel::getSetColorsMap() const {
     }
     else {
         return colors.heroColors;
+    }
+}
+
+const std::list<std::string>& CustomModel::getDefaultColorsOrdering() const {
+    if(casual) {
+        return casualOrdering;
+    }
+    else {
+        return heroOrdering;
     }
 }
 

--- a/customizer/model.hpp
+++ b/customizer/model.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <list>
 #include <filesystem>
 
 enum struct [[nodiscard]] ModelError {
@@ -39,9 +40,13 @@ private:
 public:
     bool casual;
     std::string modelName;
+    // holds ordering of the customizable colors in the gui
+    std::list<std::string> heroOrdering;
+    std::list<std::string> casualOrdering;
 
     const ColorMap_t& getDefaultColorsMap() const;
     const ColorMap_t& getSetColorsMap() const;
+    const std::list<std::string>& getDefaultColorsOrdering() const;
     const std::vector<ColorPreset>& getPresets() const;
     const ColorPreset& getDefaultPreset() const;
     const std::string& getColor(const std::string& name_) const;

--- a/gui/player_customization.cpp
+++ b/gui/player_customization.cpp
@@ -248,7 +248,8 @@ void MainWindow::setup_color_options() {
         }
     }
 
-    for (auto& [customColorName, defaultColor] : baseColors) {
+    for (auto& customColorName : model.getDefaultColorsOrdering()) {
+        auto& defaultColor = baseColors[customColorName];
 
         auto optionName = "custom_color_" + customColorName;
         auto colorWidget = new QWidget();


### PR DESCRIPTION
Title. Fixes #73. Changes the maps in the `metadata.yaml` file into a sequence so that the ordering is preserved.