### PR TITLE
Small Updates and Logic Fix

### DIFF
--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -301,6 +301,11 @@ private:
     QColor itemsColor = {105, 137, 28, 255};
     QColor locationsColor = {160, 160, 160, 255};
     QColor statsColor = {79, 79, 79, 255};
+    std::list<std::tuple<std::string, QColor*, QString>> color_preferences = {
+      {"items_color", &itemsColor, "override_items_color"},
+      {"locations_color", &locationsColor, "override_locations_color"},
+      {"stats_color", &statsColor, "override_stats_color"},
+    };
 
     using TIB = TrackerInventoryButton;
 

--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -121,6 +121,7 @@ private slots:
     void on_output_folder_browse_button_clicked();
     void on_output_folder_textChanged(const QString &arg1);
     void on_generate_seed_button_clicked();
+    void on_open_logs_folder_button_clicked();
 
 
     // Progression Locations
@@ -268,9 +269,7 @@ private slots:
     void update_stats_color();
     void on_override_stats_color_stateChanged(int arg1);
     void on_stats_color_clicked();
-
-
-    void on_open_logs_folder_button_clicked();
+    void on_show_location_logic_stateChanged(int arg1);
 
 private:
     // More Tracker Stuff

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -69,7 +69,7 @@
            <string notr="true"/>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>5</number>
           </property>
           <widget class="QWidget" name="getting_started_tab">
            <attribute name="title">
@@ -2988,6 +2988,45 @@ color: lightgray</string>
                 <string>Override Locations Background Color</string>
                </property>
               </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="gridLayoutWidget_2">
+            <property name="geometry">
+             <rect>
+              <x>820</x>
+              <y>550</y>
+              <width>221</width>
+              <height>80</height>
+             </rect>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_10">
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="show_location_logic">
+               <property name="styleSheet">
+                <string notr="true">background: rgba(79, 79, 79, 0.85);
+color: lightgray</string>
+               </property>
+               <property name="text">
+                <string>Show Location Logic</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <spacer name="verticalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </widget>

--- a/gui/tracker/tracker.cpp
+++ b/gui/tracker/tracker.cpp
@@ -1299,9 +1299,20 @@ void MainWindow::set_areas_entrances()
     // Only list non-primary entrances if entrances are decoupled
     for (auto& entrance : trackerWorld.getShuffledEntrances(EntranceType::ALL, !trackerWorld.getSettings().decouple_entrances))
     {
+        // Set Misc Restrictive Entrances as Misc so that they get properly picked up
         if (entrance->getEntranceType() == EntranceType::MISC_RESTRICTIVE)
         {
             entrance->setEntranceType(EntranceType::MISC);
+        }
+        // Same thing for Fairy Fountains as Caves
+        if (entrance->getEntranceType() == EntranceType::FAIRY)
+        {
+            entrance->setEntranceType(EntranceType::CAVE);
+        }
+        // And for the Reverse
+        if (entrance->getEntranceType() == EntranceType::FAIRY_REVERSE)
+        {
+            entrance->setEntranceType(EntranceType::CAVE_REVERSE);
         }
         auto islands = entrance->getParentArea()->findIslands();
         auto dungeons = entrance->getParentArea()->findDungeons();

--- a/gui/tracker/tracker_area_widget.cpp
+++ b/gui/tracker/tracker_area_widget.cpp
@@ -100,7 +100,7 @@ void TrackerAreaWidget::updateArea()
     {
         locationsRemaining.setStyleSheet("color: black;");
     }
-    else if (totalAccessibleLocations == 0)
+    else if (totalAccessibleLocations == 0 && showLogic)
     {
         locationsRemaining.setStyleSheet("color: red;");
     }
@@ -109,7 +109,15 @@ void TrackerAreaWidget::updateArea()
         locationsRemaining.setStyleSheet("color: blue;");
     }
 
-    std::string locationsRemainingText = std::to_string(totalAccessibleLocations) + "/" + std::to_string(totalRemainingLocations);
+    std::string locationsRemainingText = "";
+    if (showLogic)
+    {
+        locationsRemainingText = std::to_string(totalAccessibleLocations) + "/" + std::to_string(totalRemainingLocations);
+    }
+    else
+    {
+        locationsRemainingText = std::to_string(totalRemainingLocations);
+    }
     locationsRemaining.setText(locationsRemainingText.c_str());
 
     updateBossImageWidget();
@@ -127,6 +135,12 @@ void TrackerAreaWidget::updateBossImageWidget()
                               "background-image: url(" DATA_PATH "tracker/" + filename + ".png);"
                               "background-repeat: none;"
                               "background-position: center;").c_str());
+}
+
+void TrackerAreaWidget::updateShowLogic(int show)
+{
+    showLogic = show ? true : false;
+    updateArea();
 }
 
 void TrackerAreaWidget::enterEvent(QEnterEvent* e)

--- a/gui/tracker/tracker_area_widget.hpp
+++ b/gui/tracker/tracker_area_widget.hpp
@@ -32,6 +32,7 @@ public:
     std::unordered_map<std::string, LocationSet>* areaLocations;
     int totalRemainingLocations = 0;
     int totalAccessibleLocations = 0;
+    bool showLogic = true;
 
     // Stuff for other area widgets
     QWidget dungeonItemWidget = QWidget();
@@ -46,7 +47,7 @@ public:
     void setChart(TrackerInventoryButton* chart);
     void updateArea();
     void updateBossImageWidget();
-
+    void updateShowLogic(int show);
 
 signals:
     void mouse_over_area(TrackerAreaWidget* areaPrefix);

--- a/gui/tracker/tracker_label.cpp
+++ b/gui/tracker/tracker_label.cpp
@@ -162,7 +162,7 @@ void TrackerLabel::update_colors()
         {
             setStyleSheet("color: black; text-decoration: line-through;");
         }
-        else if (!location->hasBeenFound)
+        else if (!location->hasBeenFound && showLogic)
         {
             setStyleSheet("color: red;");
         }
@@ -193,4 +193,10 @@ void TrackerLabel::update_colors()
     }
 
 
+}
+
+void TrackerLabel::updateShowLogic(int show)
+{
+    showLogic = show ? true : false;
+    update_colors();
 }

--- a/gui/tracker/tracker_label.hpp
+++ b/gui/tracker/tracker_label.hpp
@@ -25,6 +25,7 @@ public:
     Entrance* get_entrance() const;
     void update_colors();
     void mark_location();
+    void updateShowLogic(int show);
 
 signals:
     void location_label_clicked();
@@ -45,4 +46,5 @@ private:
     TrackerLabelType type = TrackerLabelType::NONE;
     Location* location = nullptr;
     Entrance* entrance = nullptr;
+    bool showLogic = true;
 };

--- a/logic/data/world.yaml
+++ b/logic/data/world.yaml
@@ -614,6 +614,7 @@
   Exits:
       Windfall Island: Nothing
       Windfall Battle Squid Interior: Nothing
+      Windfall Lenzo's House Upper Ledge: "'Activate_Windmill'"
 
 - Name: Windfall House of Wealth Lower
   Locations:


### PR DESCRIPTION
- Add a Show Location Logic checkbox to the tracker. When unchecked, location logic will not be shown.
- Autosave the tracker override colors to the tracker preferences so they persist.
- Fix the logic for entering the upper door to Lenzo's House.
- Fix Fairy Fountain entrances not showing up if they weren't mixed.