### PR TITLE
Fix calculation for dungeons' outside dependent locations

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1187,10 +1187,6 @@ void MainWindow::load_locations()
             }
             locationCategories.back().insert(cat);
         }
-        if (locationObject["Dungeon Dependency"])
-        {
-            locationCategories.back().insert(LocationCategory::Dungeon);
-        }
     }
 }
 

--- a/logic/Generate.cpp
+++ b/logic/Generate.cpp
@@ -172,7 +172,7 @@ int generateWorlds(WorldPool& worlds, std::vector<Settings>& settingsVector)
       // dungeons which can be properly reached depending on any entrance rando settings
       for (auto& world : worlds)
       {
-          WORLD_LOADING_ERROR_CHECK(world.setDungeonLocations());
+          WORLD_LOADING_ERROR_CHECK(world.setDungeonLocations(worlds));
           WORLD_LOADING_ERROR_CHECK(world.determineRaceModeDungeons(worlds));
       }
 

--- a/logic/Search.cpp
+++ b/logic/Search.cpp
@@ -156,7 +156,7 @@ void explore(const SearchMode& searchMode, WorldPool& worlds, const ItemMultiSet
 // Argument 2 is a copy of the passed in ItemPool since we want to modify
 // it locally. If worldToSearch is not -1 then only the world with that worldId
 // will be searched.
-static LocationPool search(const SearchMode& searchMode, WorldPool& worlds, ItemPool items, int worldToSearch = -1)
+LocationPool search(const SearchMode& searchMode, WorldPool& worlds, ItemPool items, int worldToSearch /* = -1 */)
 {
     // Add starting inventory items to the pool of items
     for (auto& world : worlds)

--- a/logic/Search.hpp
+++ b/logic/Search.hpp
@@ -14,6 +14,7 @@ enum struct SearchMode
     GeneratePlaythrough,
 };
 
+LocationPool search(const SearchMode& searchMode, WorldPool& worlds, ItemPool items, int worldToSearch = -1);
 LocationPool getAccessibleLocations(WorldPool& worlds, ItemPool& items, LocationPool& allowedLocations, int worldToSearch = -1);
 void runGeneralSearch(WorldPool& worlds, int worldToSearch = -1);
 bool gameBeatable(WorldPool& worlds);

--- a/logic/World.hpp
+++ b/logic/World.hpp
@@ -86,7 +86,7 @@ public:
     void addSpoilsToStartingGear();
     void determineChartMappings();
     WorldLoadingError determineProgressionLocations();
-    WorldLoadingError setDungeonLocations();
+    WorldLoadingError setDungeonLocations(WorldPool& worlds);
     WorldLoadingError determineRaceModeDungeons(WorldPool& worlds);
     int loadWorld(const std::string& worldFilePath, const std::string& macrosFilePath, const std::string& locationDataPath, const std::string& itemDataPath, const std::string& areaDataPath);
     Entrance* getEntrance(const std::string& parentArea, const std::string& connectedArea);

--- a/logic/data/location_data.yaml
+++ b/logic/data/location_data.yaml
@@ -29,9 +29,9 @@
     Spanish: Buzón de correo - Carta de Novi
     French: Boîte aux Lettres - Lettre du Commis de la Poste
   Original Item: Red Rupee
-  Dungeon Dependency: Earth Temple
   Category:
     - Mail
+    - Dungeon # Requires Beating Jalhalla
   Hint Priority: Sometimes
   Type: RPX
   Offsets:
@@ -102,9 +102,9 @@
     Spanish: Buzón de correo - Carta de Orca
     French: Boîte aux Lettres - Lettre d'Orco
   Original Item: Red Rupee
-  Dungeon Dependency: Forbidden Woods
   Category:
     - Mail
+    - Dungeon # Requires beating Kalle Demos
   Hint Priority: Sometimes
   Type: RPX
   Offsets:
@@ -127,9 +127,9 @@
     Spanish: Buzón de correo - Carta de Abril
     French: Boîte aux Lettres - Lettre d'Arielle
   Original Item: Red Rupee
-  Dungeon Dependency: Forsaken Fortress
   Category:
     - Mail
+    - Dungeon # Requires beating Helmaroc King
   Hint Priority: Sometimes
   Type: RPX
   Offsets:
@@ -140,10 +140,10 @@
     Spanish: Buzón de correo - Carta de Tingle
     French: Boîte aux Lettres - Lettre de Tingle
   Original Item: INcredible Chart
-  Dungeon Dependency: Forsaken Fortress
   Category:
     - Mail
     - Expensive Purchase
+    - Dungeon # Requires beating Helmaroc King
   Hint Priority: Sometimes
   Type: RPX
   Offsets:


### PR DESCRIPTION
Locations that required beating specific bosses (i.e. `Letter from Aryll` or `Letter from Tingle`) were tied to the dungeon of the boss instead of the boss itself. This meant that when boss entrances were randomized, these locations could still be considered progression even if their dungeon's boss was nonprogress due to race mode. This fixes that possibility by instead calculating a dungeon's outside dependent locations after entrance randomization has taken place.