### PR TITLE
Add Option to Show Non-Progress Locations in Tracker

### DIFF
--- a/gui/mainwindow.hpp
+++ b/gui/mainwindow.hpp
@@ -271,6 +271,7 @@ private slots:
     void on_override_stats_color_stateChanged(int arg1);
     void on_stats_color_clicked();
     void on_show_location_logic_stateChanged(int arg1);
+    void on_show_nonprogress_locations_stateChanged(int arg1);
 
 private:
     // More Tracker Stuff

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -3021,7 +3021,7 @@ color: lightgray</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="3" column="0">
               <spacer name="verticalSpacer_5">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
@@ -3033,6 +3033,17 @@ color: lightgray</string>
                 </size>
                </property>
               </spacer>
+             </item>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="show_nonprogress_locations">
+               <property name="styleSheet">
+                <string notr="true">background: rgba(79, 79, 79, 0.85);
+color: lightgray</string>
+               </property>
+               <property name="text">
+                <string>Show Non-Progress Locations</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/gui/tracker/tracker_area_widget.cpp
+++ b/gui/tracker/tracker_area_widget.cpp
@@ -101,7 +101,10 @@ void TrackerAreaWidget::updateArea()
     }
 
     totalRemainingLocations = std::count_if(areaLocations->at(areaPrefix).begin(), areaLocations->at(areaPrefix).end(), [](Location* loc){return !loc->marked;});
+    auto remainingProgressLocations = std::count_if(areaLocations->at(areaPrefix).begin(), areaLocations->at(areaPrefix).end(), [](Location* loc){return !loc->marked && loc->progression;});
     totalAccessibleLocations = std::count_if(areaLocations->at(areaPrefix).begin(), areaLocations->at(areaPrefix).end(), [](Location* loc){return loc->hasBeenFound && !loc->marked;});
+    auto accessibleNonProgressLocations = std::count_if(areaLocations->at(areaPrefix).begin(), areaLocations->at(areaPrefix).end(), [](Location* loc){return loc->hasBeenFound && !loc->marked && !loc->progression;});
+    auto accessibleProgressLocations = totalAccessibleLocations - accessibleNonProgressLocations;
 
     if (totalRemainingLocations == 0 && totalAccessibleLocations == 0)
     {
@@ -110,6 +113,10 @@ void TrackerAreaWidget::updateArea()
     else if (totalAccessibleLocations == 0 && showLogic)
     {
         locationsRemaining.setStyleSheet("color: red;");
+    }
+    else if (showNonprogress && ((accessibleProgressLocations == 0 && showLogic) || (remainingProgressLocations == 0 && !showLogic)))
+    {
+        locationsRemaining.setStyleSheet("color: olive");
     }
     else
     {
@@ -160,7 +167,17 @@ void TrackerAreaWidget::updateBossImageWidget()
 void TrackerAreaWidget::updateShowLogic(int show, bool started)
 {
     showLogic = show ? true : false;
-    if(started) {
+    if(started)
+    {
+        updateArea();
+    }
+}
+
+void TrackerAreaWidget::updateShowNonprogress(int show, bool started)
+{
+    showNonprogress = show ? true : false;
+    if (started)
+    {
         updateArea();
     }
 }

--- a/gui/tracker/tracker_area_widget.hpp
+++ b/gui/tracker/tracker_area_widget.hpp
@@ -34,6 +34,7 @@ public:
     int totalRemainingLocations = 0;
     int totalAccessibleLocations = 0;
     bool showLogic = true;
+    bool showNonprogress = false;
 
     // Stuff for other area widgets
     QWidget dungeonItemWidget = QWidget();
@@ -50,6 +51,7 @@ public:
     void updateArea();
     void updateBossImageWidget();
     void updateShowLogic(int show, bool started);
+    void updateShowNonprogress(int show, bool started);
 
 signals:
     void mouse_over_area(TrackerAreaWidget* areaPrefix);

--- a/gui/tracker/tracker_label.cpp
+++ b/gui/tracker/tracker_label.cpp
@@ -183,6 +183,10 @@ void TrackerLabel::update_colors()
         {
             setStyleSheet("color: red;");
         }
+        else if (!location->progression)
+        {
+            setStyleSheet("color: olive;");
+        }
         else
         {
             setStyleSheet("color: blue;");


### PR DESCRIPTION
Adds a checkbox to toggle displaying non-progress locations similar to the gamecube tracker; following the suggestion on #95 . 