### PR TITLE
Fix permalink not saving randomize caves properly

### DIFF
--- a/seedgen/permalink.cpp
+++ b/seedgen/permalink.cpp
@@ -216,11 +216,12 @@ std::string create_permalink(const Settings& settings, const std::string& seed) 
             bitsWriter.write(settings.getSetting(option), 8);
         }
         // 3-bit SpinBox options
-        else if (option == Option::ProgressDungeons ||
-                 option == Option::PathHints        ||
-                 option == Option::BarrenHints      ||
-                 option == Option::LocationHints    ||
-                 option == Option::ItemHints        ||
+        else if (option == Option::ProgressDungeons       ||
+                 option == Option::RandomizeCaveEntrances ||
+                 option == Option::PathHints              ||
+                 option == Option::BarrenHints            ||
+                 option == Option::LocationHints          ||
+                 option == Option::ItemHints              ||
                  option == Option::StartingHC)
         {
             bitsWriter.write(settings.getSetting(option), 3);


### PR DESCRIPTION
Randomize caves was being treated as a binary option instead of a setting with 3 options by the permalink (so, `Disabled` and `Caves and Fairies` were being treated as the same thing).