### PR TITLE
Revert to checking macros instead of substituting them directly

### DIFF
--- a/logic/Area.cpp
+++ b/logic/Area.cpp
@@ -394,7 +394,7 @@ std::string roomNumToIslandName(const uint8_t& startingIslandRoomNum)
         "Five Star Isles",
     };
 
-    if(startingIslandRoomNum <= 0 || startingIslandRoomNum >= 49) {
+    if(startingIslandRoomNum <= 0 || startingIslandRoomNum >= 50) {
         return "INVALID";
     }
 

--- a/logic/Requirements.hpp
+++ b/logic/Requirements.hpp
@@ -49,7 +49,7 @@ struct Requirement
 
     void simplifyParenthesis();
     void sortArgs();
-    std::unordered_set<GameItem> getItems();
+    std::unordered_set<GameItem> getItems(World* world);
 };
 
 bool evaluateRequirement(World* world, const Requirement& req, const ItemMultiSet* ownedItems, const EventSet* ownedEvents);

--- a/logic/World.cpp
+++ b/logic/World.cpp
@@ -1442,7 +1442,7 @@ void World::flattenLogicRequirements()
     // for this location.
     for (auto& [name, loc] : locationTable)
     {
-        loc->itemsInComputedRequirement = loc->computedRequirement.getItems();
+        loc->itemsInComputedRequirement = loc->computedRequirement.getItems(this);
 
         // For each item listed, set this location as a chain
         // location of the item

--- a/logic/flatten/flatten.cpp
+++ b/logic/flatten/flatten.cpp
@@ -233,6 +233,9 @@ DNF evaluatePartialRequirement(BitIndex& bitIndex, const Requirement& req, Flatt
         event = std::get<EventId>(req.args[0]);
         return search->eventExprs[event];
 
+    case RequirementType::MACRO:
+        return evaluatePartialRequirement(bitIndex, search->world->macros[std::get<MacroIndex>(req.args[0])], search);
+
     // count requirements frequently have to unify with weaker terms,
     // so a count requirement always requires all lesser item counts too.
     // this ensures redundant terms can be eliminated


### PR DESCRIPTION
Reverts logic parsing of macros back to the previous behavior of checking the original macro instead of just substituting the macro requirement directly. This fixes the randomizer charts issue.

Also fixes an off by one error in `roomNumToIslandName` that was causing the logic tests to fail.