### PR TITLE
Fix edge case in flattening algorithm

### DIFF
--- a/logic/flatten/flatten.cpp
+++ b/logic/flatten/flatten.cpp
@@ -11,13 +11,13 @@ FlattenSearch::FlattenSearch(World* world_) {
         for (auto& exit : area->exits)
         {
             auto visit = visitor(&exit, this);
-            visitReq(exit.getRequirement(), visit);
+            visitReq(exit.getRequirement(), visit, world);
         }
 
         for (auto& event : area->events)
         {
             auto visit = visitor(&event, this);
-            visitReq(event.requirement, visit);
+            visitReq(event.requirement, visit, world);
         }
     }
 

--- a/logic/flatten/flatten.hpp
+++ b/logic/flatten/flatten.hpp
@@ -74,15 +74,19 @@ std::function<void(const Requirement& req)> visitor(T* thing, FlattenSearch* sea
 }
 
 template<typename Func>
-void visitReq(const Requirement& req, Func f)
+void visitReq(const Requirement& req, Func f, World* world)
 {
     f(req);
     if (req.type == RequirementType::AND or req.type == RequirementType::OR)
     {
         for (auto& arg : req.args)
         {
-            visitReq(std::get<Requirement>(arg), f);
+            visitReq(std::get<Requirement>(arg), f, world);
         }
+    }
+    else if (req.type == RequirementType::MACRO)
+    {
+        visitReq(world->macros[std::get<MacroIndex>(req.args[0])], f, world);
     }
 }
 

--- a/logic/flatten/flatten.hpp
+++ b/logic/flatten/flatten.hpp
@@ -2,6 +2,7 @@
 
 #include <logic/Entrance.hpp>
 #include <logic/Area.hpp>
+#include <logic/World.hpp>
 #include <logic/flatten/simplify_algebraic.hpp>
 
 #include <functional>


### PR DESCRIPTION
This edge case didn't seem to be hit currently, but if the flattening algorithm happens to search things in a particular order, it can possibly fail if it doesn't properly go through the macros first. 