### PR TITLE
Add support for loading custom player models

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+# Ensure clangd can find the compile_commands.json in the build dir.
+CompileFlags:
+  CompilationDatabase: "build"

--- a/customizer/INSTALL.md
+++ b/customizer/INSTALL.md
@@ -1,0 +1,39 @@
+# Custom Model Installation
+
+This file explains how to install a custom model into the randomizer. Support is
+currently experimental and may softlock your game!
+
+## Extracting Necessary Files
+
+Download any custom model from Gamebanana and extract the zip file. You will
+probably find a bunch of folders and from there we want to find some files :
+
+- Either a `permanent_3d.pack` file or a `Link.szs` file (ideally the latter).
+
+- Files with the following names, if present:
+  - `Jailnit.aaf`
+  - `voice_0.aw`
+
+If you could find them within a folder with a name like `Raw Files` or
+`Extra Files`, great! Otherwise, you may need to dig around folders with names
+like `Cafe` or `Common`. The `Link.szs` file is essential; the others are
+optional and the model creator might not have provided them.
+
+If you have `permanent_3d.pack` and not `Link.szs`, we'll need just a few more
+steps. You'll need to use
+[Toolbox](https://github.com/KillzXGaming/Switch-Toolbox/releases/tag/Final) to
+export a `Link.szs`. Simply open the `.pack` file in Toolbox, scroll to find
+`Link.szs`, right-click and `Export Raw Data`.
+
+## Installing on Console
+
+Access your SD card (either directly or over FTP) and find the save data for the
+randomizer app, usually `sd:/wiiu/apps/save/<8 hex digits> (TWWHD Randomizer)`.
+Inside, find a folder called `custom_models`. Create a new directory with your
+model's name and place `Link.szs`, along with the other, optional files.
+
+You can now load the randomizer app on your Wii U and select the model from the
+Color tab.
+
+Randomize the game, and you'll find link has changed into someone else! Have
+fun!

--- a/customizer/model.hpp
+++ b/customizer/model.hpp
@@ -39,7 +39,7 @@ private:
     ColorPreset colors;
 
 public:
-    bool casual;
+    bool casual, user_provided = false;
     std::string modelName;
     // holds ordering of the customizable colors in the gui
     std::list<std::string> heroOrdering;
@@ -61,8 +61,10 @@ public:
     void randomizeOrderly();
     void randomizeChaotically();
 
+    void nextModel();
+
     ModelError loadFromFolder();
-    ModelError applyModel() const;
+    ModelError applyModel() const;    
 };
 
 std::string errorToName(const ModelError& err);

--- a/gui/wiiu/OptionActions.cpp
+++ b/gui/wiiu/OptionActions.cpp
@@ -1,7 +1,9 @@
 #include "OptionActions.hpp"
+#include "utility/path.hpp"
 
 #include <algorithm>
 
+#include <filesystem>
 #include <utility/platform.hpp>
 #include <command/Log.hpp>
 #include <seedgen/seed.hpp>
@@ -516,6 +518,18 @@ namespace OptionCB {
     std::string randomizeColorsChaotically() {
         conf.settings.selectedModel.randomizeChaotically();
         return "";
+    }
+
+    std::string toggleCustomModel() {
+        conf.settings.selectedModel.nextModel();
+        return customModel();
+    }
+
+    std::string customModel() {
+        if (conf.settings.selectedModel.modelName.empty()) {
+            return "Link";
+        }
+        return conf.settings.selectedModel.modelName;
     }
 
     std::string cyclePigColor() {

--- a/gui/wiiu/OptionActions.hpp
+++ b/gui/wiiu/OptionActions.hpp
@@ -84,6 +84,8 @@ namespace OptionCB {
     std::string isCasual();
     std::string randomizeColorsOrderly();
     std::string randomizeColorsChaotically();
+    std::string toggleCustomModel();
+    std::string customModel();
 
     std::string cyclePigColor();
 

--- a/gui/wiiu/Page.cpp
+++ b/gui/wiiu/Page.cpp
@@ -1193,10 +1193,11 @@ void ColorPage::drawDRC() const {
 ColorPage::PresetsSubpage::PresetsSubpage(ColorPage& parent_) : 
     parent(parent_)
 {
-    toggles[0] = std::make_unique<ActionButton>("Casual Clothes", "Enable this if you want to wear your casual clothes instead of the Hero's Clothes.", &OptionCB::toggleCasualClothes, &OptionCB::isCasual);
-    toggles[1] = std::make_unique<ActionButton>("Randomize Colors Orderly", "", &OptionCB::randomizeColorsOrderly);
-    toggles[2] = std::make_unique<ActionButton>("Randomize Colors Chaotically", "", &OptionCB::randomizeColorsChaotically);
-    toggles[3] = std::make_unique<FunctionButton>("Select Colors Manually", "", std::bind(&ColorPage::setSubpage, &parent, Subpage::COLOR_PICKER));
+    toggles[0] = std::make_unique<ActionButton>("Link Model", "Select a model for Link. To install more, read https://github.com/mcy/TWWHD-Randomizer/tree/main/customizer/INSTALL.md", &OptionCB::toggleCustomModel, &OptionCB::customModel);
+    toggles[1] = std::make_unique<ActionButton>("Casual Clothes", "Enable this if you want to wear your casual clothes instead of the Hero's Clothes. Custom models will have their own variant of casual clothes", &OptionCB::toggleCasualClothes, &OptionCB::isCasual);
+    toggles[2] = std::make_unique<ActionButton>("Randomize Colors Orderly", "", &OptionCB::randomizeColorsOrderly);
+    toggles[3] = std::make_unique<ActionButton>("Randomize Colors Chaotically", "", &OptionCB::randomizeColorsChaotically);
+    toggles[4] = std::make_unique<FunctionButton>("Select Colors Manually", "", std::bind(&ColorPage::setSubpage, &parent, Subpage::COLOR_PICKER));
 }
 
 void ColorPage::PresetsSubpage::open() {

--- a/gui/wiiu/Page.hpp
+++ b/gui/wiiu/Page.hpp
@@ -215,7 +215,7 @@ private:
         size_t listScrollPos = 0;
         size_t selectedListIdx = 0;
 
-        std::array<std::unique_ptr<BasicButton>, 4> toggles;
+        std::array<std::unique_ptr<BasicButton>, 5> toggles;
         
     public:
         PresetsSubpage(ColorPage& parent_);

--- a/options.cpp
+++ b/options.cpp
@@ -134,6 +134,7 @@ void Settings::resetDefaultPreferences(const bool& paths) {
     ui_display = UIDisplayPreference::On;
 
     selectedModel.casual = false;
+    selectedModel.user_provided = false;
     selectedModel.modelName = "Link";
     selectedModel.resetColors();
 

--- a/randomizer.cpp
+++ b/randomizer.cpp
@@ -220,7 +220,6 @@ public:
             return 1;
         }
 
-        //IMPROVEMENT: custom model things
         if(const ModelError err = config.settings.selectedModel.applyModel(); err != ModelError::NONE) {
             ErrorLog::getInstance().log("Failed to apply custom model, error " + errorToName(err));
             return 1;

--- a/seedgen/config.cpp
+++ b/seedgen/config.cpp
@@ -405,6 +405,7 @@ ConfigError Config::loadFromFile(const fspath& filePath, const fspath& preferenc
     }
 
     GET_FIELD(preferencesRoot, "custom_player_model", settings.selectedModel.modelName)
+    GET_FIELD(preferencesRoot, "model_user_provided", settings.selectedModel.user_provided)
     if(settings.selectedModel.loadFromFolder() != ModelError::NONE) {
         if(!ignoreErrors) LOG_ERR_AND_RETURN(ConfigError::MODEL_ERROR);
     }
@@ -596,6 +597,7 @@ YAML::Node Config::preferencesToYaml() const {
     SET_FIELD(preferencesRoot, "ui_display", UIDisplayPreferenceToName(settings.ui_display))
 
     SET_FIELD(preferencesRoot, "player_in_casual_clothes", settings.selectedModel.casual)
+    SET_FIELD(preferencesRoot, "model_user_provided", settings.selectedModel.user_provided)
     SET_FIELD(preferencesRoot, "custom_player_model", settings.selectedModel.modelName)
     for (const auto& [texture, color] : settings.selectedModel.getSetColorsMap()) {
         preferencesRoot["custom_colors"][texture] = color;

--- a/utility/path.cpp
+++ b/utility/path.cpp
@@ -59,6 +59,18 @@ namespace Utility {
         return path;
     }
 
+    
+    fspath get_models_dir() {
+        const fspath path = get_app_save_path() / "custom_models/";
+
+        if (!std::filesystem::is_directory(path))
+        {
+            Utility::create_directories(path);
+        }
+
+        return path;
+    }
+
     fspath get_temp_dir() {
         // could get the OS-provided temp folder with Qt but it might be harder to find and debug should we use it for anything
         const fspath path = get_app_save_path() / "temp/";

--- a/utility/path.hpp
+++ b/utility/path.hpp
@@ -12,6 +12,7 @@ namespace Utility {
     fspath get_data_path();
     fspath get_app_save_path();
     fspath get_logs_path();
+    fspath get_models_dir();
     fspath get_temp_dir();
 
     // On Windows, fspath.string() will throw an exception if the character requires some kind of Unicode/non-ANSI representation


### PR DESCRIPTION
This PR is a re-implementation of some work by Teotia444 from a few months ago, which teaches the randomizer how to patch files for a custom model mod.

This PR contains:

1. Code for doing the patching. Right now it patches Link.szs and some files for voice clips. It should probably also patch the files for the map icon, too, but I don't know what the right destination for those is.

2. Adds a way to select a custom model in the Aroma UI. The current mechanism is not ideal or efficient, but unless people have hundreds of models I doubt the O(n log n) overhead will be noticeable. I have made it so that you can have multiple models to choose from.

I have not updated the desktop app because I have never touched Qt anything in my life, nor do I have a Windows dev machine to test with (like I have a Windows machine but I am not comfortable building for `x86_64-pc-windows`).

Also, the color tab should be renamed (`Customization`?) and it would be good if selecting a custom model hid the color selection stuff. I can probably code this up myself, but testing on-console right now is quite a hassle for me (it requires walking up and down a flight of stairs...).

That aside, I have not observed any crashes from zipping Midna around the Great Sea for a couple of hours, so it seems to work.