### PR TITLE
Fix fill issue when starting with or plandomizing a lot of spoils

### DIFF
--- a/logic/GameItem.cpp
+++ b/logic/GameItem.cpp
@@ -770,6 +770,11 @@ Item::Item(GameItem gameItemId_, World* world_) :
     gameItemId(gameItemId_),
     world(world_)
 {
+    if (junkConsumables.contains(gameItemId))
+    {
+        junkConsumable = true;
+    }
+
     if (junkItems.contains(gameItemId) || (isAnyOf(gameItemId, GameItem::HeartContainer, GameItem::PieceOfHeart) && world && world->getStartingHeartCount() >= 3))
     {
         originallyJunk = true;
@@ -889,6 +894,11 @@ void Item::setAsJunkItem()
 bool Item::isJunkItem() const
 {
     return junkItem;
+}
+
+bool Item::isConsumableJunkItem() const
+{
+    return junkConsumable;
 }
 
 bool Item::wasAlwaysJunkItem() const

--- a/logic/GameItem.hpp
+++ b/logic/GameItem.hpp
@@ -355,6 +355,38 @@ static const std::set<GameItem> junkItems = {
     GameItem::TinglesChart
 };
 
+static const std::set<GameItem> junkConsumables = {
+    GameItem::HeartDrop,
+    GameItem::GreenRupee,
+    GameItem::BlueRupee,
+    GameItem::YellowRupee,
+    GameItem::RedRupee,
+    GameItem::PurpleRupee,
+    GameItem::OrangeRupee,
+    GameItem::SmallMagicDrop,
+    GameItem::LargeMagicDrop,
+    GameItem::FiveBombs,
+    GameItem::TenBombs,
+    GameItem::TwentyBombs,
+    GameItem::ThirtyBombs,
+    GameItem::SilverRupee,
+    GameItem::TenArrows,
+    GameItem::TwentyArrows,
+    GameItem::ThirtyArrows,
+    GameItem::Fairy,
+    GameItem::YellowRupee2, //joke message
+    GameItem::ThreeHearts,
+    GameItem::JoyPendant,
+    GameItem::SkullNecklace,
+    GameItem::BokoBabaSeed,
+    GameItem::GoldenFeather,
+    GameItem::KnightsCrest,
+    GameItem::RedChuJelly,
+    GameItem::GreenChuJelly,
+    GameItem::AllPurposeBait,
+    GameItem::HyoiPear,
+};
+
 static const std::set<GameItem> dungeonItems = {
     GameItem::DRCSmallKey,
     GameItem::DRCBigKey,
@@ -406,6 +438,7 @@ public:
     void setName(const std::string& language, const Text::Type& type, const std::string& name_);
     void setAsJunkItem();
     bool isJunkItem() const;
+    bool isConsumableJunkItem() const;
     bool wasAlwaysJunkItem() const;
     bool isDungeonItem() const;
     bool isMap() const;
@@ -425,6 +458,7 @@ private:
     std::unordered_set<Location*> chainLocations = {};
     bool dungeonItem = false;
     bool junkItem = false;
+    bool junkConsumable = false;
     bool originallyJunk = false;
     World* world = nullptr; // The world that this item is *FOR*
 };


### PR DESCRIPTION
When starting with or plandomizing a lot of spoils/junk items the fill algorithm could run into the problem of there being more items to place than locations available to place items. This changes the behavior when placing junk items and will first place all non-consumable junk items (tingle bottle, special charts, etc.) before placing consumable junk items. If there are more consumable junk items than locations left to place items, some consumable junk items won't get placed.