### PR TITLE
Fix GameBeatable not being checked properly for barrenness

### DIFF
--- a/logic/Location.cpp
+++ b/logic/Location.cpp
@@ -134,6 +134,11 @@ std::string Location::getName() const
 // Calculates whether the current item can be barren given it's placement at this specific location in mind
 bool Location::currentItemCanBeBarren() const
 {
+    if (currentItem.getGameItemId() == GameItem::GameBeatable)
+    {
+        return false;
+    }
+
     if (currentItem.canBeInBarrenRegion())
     {
         return true;


### PR DESCRIPTION
GameBeatable was being treated as an item that could be barren since it wasn't properly being checked for in `Location::currentItemCanBeBarren`. This was causing Triforce Shards to be considered junk items when generating barren hints.