### PR TITLE
Add Option for Old Man Ho Ho Hints Shards

### DIFF
--- a/gui/desktop/mainwindow.cpp
+++ b/gui/desktop/mainwindow.cpp
@@ -609,6 +609,7 @@ void MainWindow::apply_config_settings()
 
     // Hints
     APPLY_CHECKBOX_SETTING(config, ui, ho_ho_hints);
+    APPLY_CHECKBOX_SETTING(config, ui, ho_ho_triforce_hints);
     APPLY_CHECKBOX_SETTING(config, ui, korl_hints);
     APPLY_CHECKBOX_SETTING(config, ui, use_always_hints);
     APPLY_CHECKBOX_SETTING(config, ui, clearer_hints);
@@ -1101,6 +1102,7 @@ void MainWindow::on_player_in_casual_clothes_stateChanged(int arg1) {
 
 // Advanced Options
 DEFINE_STATE_CHANGE_FUNCTION(ho_ho_hints)
+DEFINE_STATE_CHANGE_FUNCTION(ho_ho_triforce_hints)
 DEFINE_STATE_CHANGE_FUNCTION(korl_hints)
 DEFINE_STATE_CHANGE_FUNCTION(use_always_hints)
 DEFINE_STATE_CHANGE_FUNCTION(clearer_hints)

--- a/gui/desktop/mainwindow.hpp
+++ b/gui/desktop/mainwindow.hpp
@@ -237,6 +237,7 @@ private slots:
 
     // Hints
     void on_ho_ho_hints_stateChanged(int arg1);
+    void on_ho_ho_triforce_hints_stateChanged(int arg1);
     void on_korl_hints_stateChanged(int arg1);
     void on_use_always_hints_stateChanged(int arg1);
     void on_path_hints_valueChanged(int path_hints);

--- a/gui/desktop/mainwindow.ui
+++ b/gui/desktop/mainwindow.ui
@@ -69,7 +69,7 @@
            <string notr="true"/>
           </property>
           <property name="currentIndex">
-           <number>6</number>
+           <number>5</number>
           </property>
           <widget class="QWidget" name="getting_started_tab">
            <attribute name="title">
@@ -1840,34 +1840,6 @@
                <string>Hints</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_8">
-               <item row="2" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_8">
-                 <item>
-                  <widget class="QLabel" name="label_for_path_hints">
-                   <property name="text">
-                    <string>Path Hints</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="path_hints">
-                   <property name="maximum">
-                    <number>7</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QWidget" name="widget_3" native="true"/>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="korl_hints">
-                 <property name="text">
-                  <string>Place Hints on King of Red Lions</string>
-                 </property>
-                </widget>
-               </item>
                <item row="2" column="2">
                 <layout class="QHBoxLayout" name="horizontalLayout_15">
                  <item>
@@ -1896,6 +1868,48 @@
                  </item>
                 </layout>
                </item>
+               <item row="3" column="0">
+                <widget class="QCheckBox" name="use_always_hints">
+                 <property name="text">
+                  <string>Use Always Hints</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_8">
+                 <item>
+                  <widget class="QLabel" name="label_for_path_hints">
+                   <property name="text">
+                    <string>Path Hints</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="path_hints">
+                   <property name="maximum">
+                    <number>7</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QWidget" name="widget_3" native="true"/>
+                 </item>
+                </layout>
+               </item>
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="ho_ho_hints">
+                 <property name="text">
+                  <string>Place Hints on Old Man Ho Ho</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="2">
+                <widget class="QCheckBox" name="hint_importance">
+                 <property name="text">
+                  <string>Hint Importance</string>
+                 </property>
+                </widget>
+               </item>
                <item row="2" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayout_14">
                  <item>
@@ -1917,10 +1931,10 @@
                  </item>
                 </layout>
                </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="ho_ho_hints">
+               <item row="3" column="1">
+                <widget class="QCheckBox" name="clearer_hints">
                  <property name="text">
-                  <string>Place Hints on Old Man Ho Ho</string>
+                  <string>Clearer Hints</string>
                  </property>
                 </widget>
                </item>
@@ -1945,24 +1959,17 @@
                  </item>
                 </layout>
                </item>
-               <item row="3" column="0">
-                <widget class="QCheckBox" name="use_always_hints">
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="korl_hints">
                  <property name="text">
-                  <string>Use Always Hints</string>
+                  <string>Place Hints on King of Red Lions</string>
                  </property>
                 </widget>
                </item>
-               <item row="3" column="1">
-                <widget class="QCheckBox" name="clearer_hints">
+               <item row="4" column="0">
+                <widget class="QCheckBox" name="ho_ho_triforce_hints">
                  <property name="text">
-                  <string>Clearer Hints</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QCheckBox" name="hint_importance">
-                 <property name="text">
-                  <string>Hint Importance</string>
+                  <string>Old Man Ho Ho Hints Shards</string>
                  </property>
                 </widget>
                </item>

--- a/gui/desktop/option_descriptions.hpp
+++ b/gui/desktop/option_descriptions.hpp
@@ -293,6 +293,10 @@ static std::unordered_map<std::string, std::string> optionDescriptions = {
       "Places hints on Old Man Ho Ho. Old Man Ho Ho appears at 10 different islands in the game. Simply talk to Old Man Ho Ho to get hints.",
     },
     {
+      "ho_ho_triforce_hints",
+      "When this option is selected, each Old Man Ho Ho will give an item hint for a Triforce Shard. Hints are not repeated until each shard is hinted once. This setting will override placing other hints on Old Man Ho Ho.",
+    },
+    {
       "korl_hints",
       "Places hints on the King of Red Lions. Talk to the King of Red Lions to get hints.",
     },

--- a/gui/wiiu/OptionActions.cpp
+++ b/gui/wiiu/OptionActions.cpp
@@ -342,6 +342,11 @@ namespace OptionCB {
         return fromBool(conf.settings.ho_ho_hints);
     }
 
+    std::string toggleHoHoTriforceHints() {
+        conf.settings.ho_ho_triforce_hints = !conf.settings.ho_ho_triforce_hints;
+        return fromBool(conf.settings.ho_ho_hints);
+    }
+
     std::string toggleKorlHints() {
         conf.settings.korl_hints = !conf.settings.korl_hints;
         return fromBool(conf.settings.korl_hints);
@@ -969,6 +974,8 @@ std::string getValue(const Option& option) {
             return fromBool(conf.settings.decouple_entrances);
         case Option::HoHoHints:
             return fromBool(conf.settings.ho_ho_hints);
+        case Option::HoHoTriforceHints:
+            return fromBool(conf.settings.ho_ho_triforce_hints);
         case Option::KorlHints:
             return fromBool(conf.settings.korl_hints);
         case Option::ClearerHints:
@@ -1177,6 +1184,8 @@ TriggerCallback getCallback(const Option& option) {
             return &toggleDecoupleEntrances;
         case Option::HoHoHints:
             return &toggleHoHoHints;
+        case Option::HoHoTriforceHints:
+            return &toggleHoHoTriforceHints;
         case Option::KorlHints:
             return &toggleKorlHints;
         case Option::ClearerHints:
@@ -1341,6 +1350,7 @@ std::pair<std::string, std::string> getNameDesc(const Option& option) {
         {Plandomizer,                {"Plandomizer",                         "Allows you to provide a file which manually sets item locations and/or entrances."}},
 
         {HoHoHints,                  {"Place Hints on Old Man Ho Ho",        "Places hints on Old Man Ho Ho. Old Man Ho Ho appears at 10 different islands. Simply talk to Old Man Ho Ho to get hints."}},
+        {HoHoTriforceHints,          {"Old Man Ho Ho Hints Shards",          "When this option is selected, each Old Man Ho Ho will give an item hint for a Triforce Shard. Hints are not repeated until each shard is hinted once. This setting will override placing other hints on Old Man Ho Ho."}},
         {KorlHints,                  {"Place Hints on King of Red Lions",    "Places hints on the King of Red Lions. Talk to the King of Red Lions to get hints."}},
         {ClearerHints,               {"Clearer Hints",                       "When this option is selected, location and item hints will use the standard check or item name, instead of using cryptic hints."}},
         {UseAlwaysHints,             {"Use Always Hints",                    "When the number of location hints is nonzero, certain locations that will always be hinted will take precedence over normal location hints."}},

--- a/gui/wiiu/OptionActions.hpp
+++ b/gui/wiiu/OptionActions.hpp
@@ -57,6 +57,7 @@ namespace OptionCB {
     std::string toggleDecoupleEntrances();
 
     std::string toggleHoHoHints();
+    std::string toggleHoHoTriforceHints();
     std::string toggleKorlHints();
     std::string toggleClearHints();
     std::string toggleAlwaysHints();

--- a/gui/wiiu/Page.cpp
+++ b/gui/wiiu/Page.cpp
@@ -268,6 +268,7 @@ HintsPage::HintsPage() {
 
     // we can't use an initializer list for a vector<unique_ptr> because of copy/move issues
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::HoHoHints));
+    buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::HoHoTriforceHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::KorlHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::ClearerHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::UseAlwaysHints));

--- a/logic/GameItem.cpp
+++ b/logic/GameItem.cpp
@@ -931,6 +931,11 @@ bool Item::isBigKey() const
     return bigKeys.contains(gameItemId);
 }
 
+bool Item::isTriforceShard() const
+{
+    return gameItemId >= GameItem::TriforceShard1 && gameItemId <= GameItem::TriforceShard8;
+}
+
 bool Item::isValidItem() const
 {
     return isNoneOf(gameItemId, GameItem::INVALID, GameItem::NOTHING);

--- a/logic/GameItem.hpp
+++ b/logic/GameItem.hpp
@@ -444,6 +444,7 @@ public:
     bool isCompass() const;
     bool isSmallKey() const;
     bool isBigKey() const;
+    bool isTriforceShard() const;
     bool isValidItem() const;
     bool canBeInBarrenRegion() const;
     bool operator==(const Item& rhs) const;

--- a/options.cpp
+++ b/options.cpp
@@ -62,6 +62,7 @@ void Settings::resetDefaultSettings() {
 
     korl_hints = false;
     ho_ho_hints = false;
+    ho_ho_triforce_hints = false;
     path_hints = false;
     barren_hints = false;
     item_hints = false;
@@ -230,6 +231,8 @@ uint8_t Settings::getSetting(const Option& option) const {
             return decouple_entrances;
         case Option::HoHoHints:
             return ho_ho_hints;
+        case Option::HoHoTriforceHints:
+            return ho_ho_triforce_hints;
         case Option::KorlHints:
             return korl_hints;
         case Option::ClearerHints:
@@ -415,6 +418,8 @@ void Settings::setSetting(const Option& option, const size_t& value) {
             decouple_entrances = value; return;
         case Option::HoHoHints:
             ho_ho_hints = value; return;
+        case Option::HoHoTriforceHints:
+            ho_ho_triforce_hints = value; return;
         case Option::KorlHints:
             korl_hints = value; return;
         case Option::ClearerHints:
@@ -901,6 +906,7 @@ Option nameToSetting(const std::string& name) {
         {"Mix Misc", Option::MixMisc},
         {"Decouple Entrances", Option::DecoupleEntrances},
         {"Ho Ho Hints", Option::HoHoHints},
+        {"Ho Ho Triforce Hints", Option::HoHoTriforceHints},
         {"Korl Hints", Option::KorlHints},
         {"Clearer Hints", Option::ClearerHints},
         {"Use Always Hints", Option::UseAlwaysHints},
@@ -1001,6 +1007,7 @@ std::string settingToName(const Option& setting) {
         {Option::MixMisc, "Mix Misc"},
         {Option::DecoupleEntrances, "Decouple Entrances"},
         {Option::HoHoHints, "Ho Ho Hints"},
+        {Option::HoHoTriforceHints, "Ho Ho Triforce Hints"},
         {Option::KorlHints, "Korl Hints"},
         {Option::ClearerHints, "Clearer Hints"},
         {Option::UseAlwaysHints, "Use Always Hints"},

--- a/options.hpp
+++ b/options.hpp
@@ -173,6 +173,7 @@ enum struct Option {
 
     // Hints
     HoHoHints,
+    HoHoTriforceHints,
     KorlHints,
     ClearerHints,
     UseAlwaysHints,
@@ -263,6 +264,7 @@ public:
     bool decouple_entrances;
 
     bool ho_ho_hints;
+    bool ho_ho_triforce_hints;
     bool korl_hints;
     bool clearer_hints;
     bool use_always_hints;

--- a/seedgen/config.cpp
+++ b/seedgen/config.cpp
@@ -194,6 +194,7 @@ ConfigError Config::loadFromFile(const fspath& filePath, const fspath& preferenc
     GET_FIELD(root, "decouple_entrances", settings.decouple_entrances)
 
     GET_FIELD(root, "ho_ho_hints", settings.ho_ho_hints)
+    GET_FIELD(root, "ho_ho_triforce_hints", settings.ho_ho_triforce_hints)
     GET_FIELD(root, "korl_hints", settings.korl_hints)
     GET_FIELD(root, "clearer_hints", settings.clearer_hints)
     GET_FIELD(root, "use_always_hints", settings.use_always_hints)
@@ -522,6 +523,7 @@ YAML::Node Config::settingsToYaml() const {
     SET_FIELD(root, "decouple_entrances", settings.decouple_entrances)
 
     SET_FIELD(root, "ho_ho_hints", settings.ho_ho_hints)
+    SET_FIELD(root, "ho_ho_triforce_hints", settings.ho_ho_triforce_hints)
     SET_FIELD(root, "korl_hints", settings.korl_hints)
     SET_FIELD(root, "clearer_hints", settings.clearer_hints)
     SET_FIELD(root, "use_always_hints", settings.use_always_hints)
@@ -797,6 +799,7 @@ static const std::vector<Option> PERMALINK_OPTIONS {
 
     // Hints
     Option::HoHoHints,
+    Option::HoHoTriforceHints,
     Option::KorlHints,
     Option::PathHints,
     Option::BarrenHints,
@@ -889,6 +892,7 @@ static size_t getOptionBitCount(const Option& option) {
         case Option::FixRNG:
         case Option::Performance:
         case Option::HoHoHints:
+        case Option::HoHoTriforceHints:
         case Option::KorlHints:
         case Option::UseAlwaysHints:
         case Option::ClearerHints:


### PR DESCRIPTION
Brings over the same option from the gamecube randomizer. If selected, item hints for Triforce Shards will be distributed among the Old Man Ho Ho hint locations and will override other hints being given to Old Man Ho Ho. Triforce Shards that are at race mode locations will not be hinted. Triforce Shards that are placed at `Always` locations will still be hinted at, even if the `Always` location has been assigned as a hint to the King of Red Lions.