### PR TITLE
Minor Actions Updates

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -48,7 +48,6 @@ jobs:
           target: 'desktop'
           arch: 'clang_64'
           cache: true
-          cache-key-prefix: install-qt-${{ env.QT_VERSION }}-action
 
       - name: Set Debug Flags
         if: inputs.build_type == 'Debug'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -57,7 +57,6 @@ jobs:
           target: 'desktop'
           arch: 'win64_msvc2022_64'
           cache: true
-          cache-key-prefix: install-qt-${{ env.QT_VERSION }}-action
 
       - name: Set Debug Flags
         if: inputs.build_type == 'Debug'


### PR DESCRIPTION
Bump Qt version, clean up some action versions/options

Only downside I've encountered so far is that debug builds are slower (because MSVC seems to have heavier debug libraries) but this should only affect nightly builds and can probably be avoided with some flags