### PR TITLE
Add setting for Kreeb Hints Bows

### DIFF
--- a/gui/desktop/mainwindow.cpp
+++ b/gui/desktop/mainwindow.cpp
@@ -608,6 +608,7 @@ void MainWindow::apply_config_settings()
     APPLY_CHECKBOX_SETTING(config, ui, ho_ho_hints);
     APPLY_CHECKBOX_SETTING(config, ui, ho_ho_triforce_hints);
     APPLY_CHECKBOX_SETTING(config, ui, korl_hints);
+    APPLY_CHECKBOX_SETTING(config, ui, kreeb_bow_hints);
     APPLY_CHECKBOX_SETTING(config, ui, use_always_hints);
     APPLY_CHECKBOX_SETTING(config, ui, clearer_hints);
     APPLY_CHECKBOX_SETTING(config, ui, hint_importance);
@@ -1102,6 +1103,7 @@ void MainWindow::on_player_in_casual_clothes_stateChanged(int arg1) {
 DEFINE_STATE_CHANGE_FUNCTION(ho_ho_hints)
 DEFINE_STATE_CHANGE_FUNCTION(ho_ho_triforce_hints)
 DEFINE_STATE_CHANGE_FUNCTION(korl_hints)
+DEFINE_STATE_CHANGE_FUNCTION(kreeb_bow_hints)
 DEFINE_STATE_CHANGE_FUNCTION(use_always_hints)
 DEFINE_STATE_CHANGE_FUNCTION(clearer_hints)
 DEFINE_STATE_CHANGE_FUNCTION(hint_importance)
@@ -1372,3 +1374,4 @@ void MainWindow::on_paste_permalink_clicked()
     auto permalink = QGuiApplication::clipboard()->text();
     on_permalink_textEdited(permalink);
 }
+

--- a/gui/desktop/mainwindow.hpp
+++ b/gui/desktop/mainwindow.hpp
@@ -240,6 +240,7 @@ private slots:
     void on_ho_ho_hints_stateChanged(int arg1);
     void on_ho_ho_triforce_hints_stateChanged(int arg1);
     void on_korl_hints_stateChanged(int arg1);
+    void on_kreeb_bow_hints_stateChanged(int arg1);
     void on_use_always_hints_stateChanged(int arg1);
     void on_path_hints_valueChanged(int path_hints);
     void on_barren_hints_valueChanged(int barren_hints);
@@ -303,9 +304,6 @@ private slots:
     void on_view_all_entrances_button_clicked();
     void open_chart_mapping_list(uint8_t islandNum);
     void tracker_give_and_map_chart(TrackerLabel* label, GameItem chart);
-
-
-
 
 public:
     void update_items_color();

--- a/gui/desktop/mainwindow.ui
+++ b/gui/desktop/mainwindow.ui
@@ -24,7 +24,7 @@
     <item>
      <widget class="QScrollArea" name="scrollArea">
       <property name="frameShape">
-       <enum>QFrame::Shape::NoFrame</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="widgetResizable">
        <bool>true</bool>
@@ -63,7 +63,7 @@
            </sizepolicy>
           </property>
           <property name="contextMenuPolicy">
-           <enum>Qt::ContextMenuPolicy::DefaultContextMenu</enum>
+           <enum>Qt::DefaultContextMenu</enum>
           </property>
           <property name="styleSheet">
            <string notr="true"/>
@@ -116,7 +116,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Playing the randomizer on console requires a Wii U with the Aroma environment and sigpatches. A guide for installing Aroma can be found &lt;a href=&quot;https://wiiu.hacks.guide&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;. After following the guide, you will need to add &lt;a href=&quot;https://github.com/marco-calautti/SigpatchesModuleWiiU/releases&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;01_sigpatches.rpx&lt;/span&gt;&lt;/a&gt; to &lt;span style=&quot; font-family:'Courier New';&quot;&gt;/wiiu/environments/aroma/modules/setup&lt;/span&gt; on your SD card. Make sure to read each page of the guide closely, and pay attention to which environment you are booting into.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -153,7 +153,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The patcher requires an accessible version of TWWHD (USA) on your Wii U (digital install or inserted disc). You must also have 2GB of space available for the randomized channel, either on the console's internal memory or a connected USB storage device (*&lt;span style=&quot; font-style:italic;&quot;&gt;This storage is reserved after the first-time setup&lt;/span&gt;).&lt;/p&gt;&lt;p&gt;Once homebrew is set up, copy &lt;span style=&quot; font-family:'Courier New';&quot;&gt;wwhd_randomizer.wuhb&lt;/span&gt; from the &lt;a href=&quot;https://github.com/SuperDude88/TWWHD-Randomizer/releases/latest&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;releases page&lt;/span&gt;&lt;/a&gt; into &lt;span style=&quot; font-family:'Courier New';&quot;&gt;/wiiu/apps&lt;/span&gt; on your SD Card. Run the app from the home menu to open the patcher. &lt;/p&gt;&lt;p&gt;Select the settings you wish to use and then follow the prompts to begin the randomization process. The first time it runs, the patcher will create a home menu channel for the randomized game. This takes some time, but it only happens once. The process of patching the randomized game itself after the new channel is created will also take a few minutes. (*&lt;span style=&quot; font-style:italic;&quot;&gt;Note: Everytime you create a new randomized game, it will overwrite any previous one that existed.)&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -184,7 +184,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To play the randomized game, you must have Aroma active. This should always be the case right after you run the patcher. The randomized channel will have an orange, mirrored icon of the vanilla game. &lt;/p&gt;&lt;p&gt;A tracker is provided for your convenience in this application. Simply click the &lt;span style=&quot; font-family:'Courier New';&quot;&gt;Start New Tracker&lt;/span&gt; button in the top right of the tracker tab. Progress made in the tracker is autosaved, so you can close the application and resume progress later if you wish.&lt;/p&gt;&lt;p&gt;You can either set the same settings in the application for the tracker, or you can retrieve the &lt;span style=&quot; font-family:'Courier New';&quot;&gt;config.yaml&lt;/span&gt; file from &lt;code&gt;/wiiu/apps/save/(hex digits)(TWWHD Randomizer)&lt;/code&gt;, close this application,  place the config file in the same folder as this application, and reopen the application to apply the settings automatically.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -222,7 +222,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Before generating a seed, you need to have a valid extract of the decrypted USA version of the game. The PAL and JP versions will not work, and neither will the original Wind Waker.&lt;/p&gt;&lt;p&gt;The decrypted copy of the game is a folder which contains three subfolders (&lt;span style=&quot; font-family:'Courier New';&quot;&gt;code&lt;/span&gt;, &lt;span style=&quot; font-family:'Courier New';&quot;&gt;content&lt;/span&gt;, and &lt;span style=&quot; font-family:'Courier New';&quot;&gt;meta&lt;/span&gt;). It is &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; a single file like a &lt;span style=&quot; font-family:'Courier New';&quot;&gt;.iso&lt;/span&gt; or a &lt;span style=&quot; font-family:'Courier New';&quot;&gt;.wad&lt;/span&gt;. You can dump a disc or digital install from your Wii U with &lt;a href=&quot;https://github.com/emiyl/dumpling/releases/latest&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;dumpling&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -247,7 +247,7 @@
                    <string>Generate a Seed</string>
                   </property>
                   <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_17">
                    <item>
@@ -256,7 +256,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;After you've obtained your decrypted copy of the game, you need to tell the randomizer where the vanilla game is, as well as where to output the randomized version of the game.&lt;/p&gt;&lt;p&gt;In the &lt;span style=&quot; font-family:'Courier New';&quot;&gt;Base Game Folder&lt;/span&gt; field below, browse to and select the folder which contains the decrypted games's three subfolders. In the &lt;span style=&quot; font-family:'Courier New';&quot;&gt;Output Folder&lt;/span&gt; field, select the folder where you want the randomized game to appear.&lt;/p&gt;&lt;p&gt;Feel free to go through the settings in the rest of the tabs to customize your experience, and when you're ready, hit the &lt;code&gt;Randomize&lt;/code&gt; button in the bottom right.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -287,7 +287,7 @@
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To play the seed, open up the &lt;a href=&quot;https://github.com/cemu-project/Cemu/releases&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#007af4;&quot;&gt;CEMU Emulator&lt;/span&gt;&lt;/a&gt;. Go to &lt;span style=&quot; font-family:'Courier New';&quot;&gt;Options &amp;gt; General Settings&lt;/span&gt;. At the bottom where you enter game paths, click &lt;span style=&quot; font-family:'Courier New';&quot;&gt;Add&lt;/span&gt; and browse for the output folder where the randomized game is. The randomized game should now appear in the games list. It has an orange icon with the King of Red Lions in it. Now launch the game in CEMU and enjoy!&lt;/p&gt;&lt;p&gt;A tracker is provided for your convenience in this application. Simply click the &lt;code&gt;Start New Tracker&lt;/code&gt; button in the tracker tab. Progress made in the tracker is autosaved, so you can close the application and resume progress later if you wish.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                      <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>
@@ -368,7 +368,7 @@
               </property>
               <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0,0,0,0,0">
                <property name="sizeConstraint">
-                <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                <enum>QLayout::SetDefaultConstraint</enum>
                </property>
                <item row="9" column="3">
                 <widget class="QCheckBox" name="progression_obscure">
@@ -894,7 +894,7 @@
                     </size>
                    </property>
                    <property name="buttonSymbols">
-                    <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                    <enum>QAbstractSpinBox::UpDownArrows</enum>
                    </property>
                    <property name="suffix">
                     <string>x</string>
@@ -1044,10 +1044,10 @@
                 <item>
                  <widget class="QListView" name="randomized_gear">
                   <property name="editTriggers">
-                   <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+                   <set>QAbstractItemView::NoEditTriggers</set>
                   </property>
                   <property name="selectionMode">
-                   <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                   <enum>QAbstractItemView::ExtendedSelection</enum>
                   </property>
                  </widget>
                 </item>
@@ -1058,7 +1058,7 @@
                 <item>
                  <spacer name="verticalSpacer_3">
                   <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
+                   <enum>Qt::Vertical</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -1109,7 +1109,7 @@
                 <item>
                  <spacer name="verticalSpacer_4">
                   <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
+                   <enum>Qt::Vertical</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -1133,10 +1133,10 @@
                 <item>
                  <widget class="QListView" name="starting_gear">
                   <property name="editTriggers">
-                   <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+                   <set>QAbstractItemView::NoEditTriggers</set>
                   </property>
                   <property name="selectionMode">
-                   <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                   <enum>QAbstractItemView::ExtendedSelection</enum>
                   </property>
                  </widget>
                 </item>
@@ -1162,7 +1162,7 @@
                  </size>
                 </property>
                 <property name="layoutDirection">
-                 <enum>Qt::LayoutDirection::LeftToRight</enum>
+                 <enum>Qt::LeftToRight</enum>
                 </property>
                 <property name="minimum">
                  <number>1</number>
@@ -1214,7 +1214,7 @@
               <item>
                <spacer name="horizontalSpacer_3">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -1297,7 +1297,7 @@
               <item>
                <spacer name="horizontalSpacer_4">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -1399,7 +1399,7 @@
                  <string>Knights Crests</string>
                 </property>
                 <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -1439,7 +1439,7 @@
                 <item>
                  <widget class="QListView" name="progression_locations">
                   <property name="editTriggers">
-                   <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+                   <set>QAbstractItemView::NoEditTriggers</set>
                   </property>
                  </widget>
                 </item>
@@ -1450,7 +1450,7 @@
                 <item>
                  <spacer name="verticalSpacer_6">
                   <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
+                   <enum>Qt::Vertical</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -1501,7 +1501,7 @@
                 <item>
                  <spacer name="verticalSpacer_7">
                   <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
+                   <enum>Qt::Vertical</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -1525,7 +1525,7 @@
                 <item>
                  <widget class="QListView" name="excluded_locations">
                   <property name="editTriggers">
-                   <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+                   <set>QAbstractItemView::NoEditTriggers</set>
                   </property>
                  </widget>
                 </item>
@@ -1696,7 +1696,7 @@
                    </sizepolicy>
                   </property>
                   <property name="frameShape">
-                   <enum>QFrame::Shape::NoFrame</enum>
+                   <enum>QFrame::NoFrame</enum>
                   </property>
                   <property name="text">
                    <string/>
@@ -1710,7 +1710,7 @@
             <item>
              <spacer name="verticalSpacer_8">
               <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -1769,7 +1769,7 @@
                <item row="6" column="0" colspan="2">
                 <layout class="QGridLayout" name="plandomizer_file_layout">
                  <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
+                  <enum>QLayout::SetNoConstraint</enum>
                  </property>
                  <item row="0" column="1">
                   <widget class="QLabel" name="plandomizer_label">
@@ -1835,7 +1835,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox_5">
+             <widget class="QGroupBox" name="hints_groupbox">
               <property name="title">
                <string>Hints</string>
               </property>
@@ -1970,6 +1970,13 @@
                 <widget class="QCheckBox" name="ho_ho_triforce_hints">
                  <property name="text">
                   <string>Old Man Ho Ho Hints Shards</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QCheckBox" name="kreeb_bow_hints">
+                 <property name="text">
+                  <string>Kreeb Hints Bows</string>
                  </property>
                 </widget>
                </item>
@@ -2466,7 +2473,7 @@ color: lightgray</string>
                <item row="0" column="0">
                 <layout class="QHBoxLayout" name="top_button_layout">
                  <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
+                  <enum>QLayout::SetMinimumSize</enum>
                  </property>
                  <item>
                   <widget class="QPushButton" name="location_list_close_button">
@@ -2535,10 +2542,10 @@ font-size: 15px;</string>
                   <string notr="true">background: transparent;</string>
                  </property>
                  <property name="frameShape">
-                  <enum>QFrame::Shape::NoFrame</enum>
+                  <enum>QFrame::NoFrame</enum>
                  </property>
                  <property name="frameShadow">
-                  <enum>QFrame::Shadow::Plain</enum>
+                  <enum>QFrame::Plain</enum>
                  </property>
                  <property name="widgetResizable">
                   <bool>true</bool>
@@ -2610,7 +2617,7 @@ font-size: 15px;</string>
                <item row="0" column="0">
                 <layout class="QHBoxLayout" name="entrance_list_top_buttons_layout">
                  <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
+                  <enum>QLayout::SetMaximumSize</enum>
                  </property>
                  <item>
                   <widget class="QPushButton" name="entrance_list_close_button">
@@ -2668,10 +2675,10 @@ font-size: 15px;</string>
                   <string notr="true">background: transparent;</string>
                  </property>
                  <property name="frameShape">
-                  <enum>QFrame::Shape::NoFrame</enum>
+                  <enum>QFrame::NoFrame</enum>
                  </property>
                  <property name="frameShadow">
-                  <enum>QFrame::Shadow::Plain</enum>
+                  <enum>QFrame::Plain</enum>
                  </property>
                  <property name="widgetResizable">
                   <bool>true</bool>
@@ -2766,7 +2773,7 @@ font-size: 15px;</string>
                   <number>6</number>
                  </property>
                  <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
+                  <enum>QLayout::SetMaximumSize</enum>
                  </property>
                  <item>
                   <widget class="QPushButton" name="entrance_destination_back_button">
@@ -2807,10 +2814,10 @@ font-size: 15px;
                   <string notr="true">background: transparent;</string>
                  </property>
                  <property name="frameShape">
-                  <enum>QFrame::Shape::NoFrame</enum>
+                  <enum>QFrame::NoFrame</enum>
                  </property>
                  <property name="frameShadow">
-                  <enum>QFrame::Shadow::Plain</enum>
+                  <enum>QFrame::Plain</enum>
                  </property>
                  <property name="widgetResizable">
                   <bool>true</bool>
@@ -2864,7 +2871,7 @@ font-size: 15px;</string>
                   <string>Where did lead to?</string>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
+                  <set>Qt::AlignCenter</set>
                  </property>
                  <property name="wordWrap">
                   <bool>true</bool>
@@ -2953,7 +2960,7 @@ font-size: 15px;</string>
                <item row="1" column="0">
                 <layout class="QGridLayout" name="chart_list_layout">
                  <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                  <enum>QLayout::SetDefaultConstraint</enum>
                  </property>
                 </layout>
                </item>
@@ -3011,7 +3018,7 @@ font-weight: bold;</string>
                 <string>0</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -3043,7 +3050,7 @@ font-weight: bold;</string>
                 <string>0</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -3057,7 +3064,7 @@ font-weight: bold;</string>
                 <string>0</string>
                </property>
                <property name="alignment">
-                <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -3109,7 +3116,7 @@ font-weight: bold;</string>
              <string/>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignHCenter</set>
+             <set>Qt::AlignBottom|Qt::AlignHCenter</set>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -3169,7 +3176,7 @@ font-weight: bold;</string>
              <string/>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
            <widget class="QLabel" name="current_area_remaining_number">
@@ -3188,7 +3195,7 @@ font-weight: bold;</string>
              <string/>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
            <widget class="QLabel" name="current_item_label">
@@ -3207,7 +3214,7 @@ font-weight: bold;</string>
              <string/>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -3248,7 +3255,7 @@ color: lightgray</string>
              <item row="3" column="0">
               <spacer name="verticalSpacer_5">
                <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
+                <enum>Qt::Vertical</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -3337,7 +3344,7 @@ color: lightgray</string>
          <string>Seed Hash:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -3383,7 +3390,7 @@ color: lightgray</string>
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -3403,7 +3410,7 @@ color: lightgray</string>
       <item>
        <spacer name="horizontalSpacer_5">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -3429,7 +3436,7 @@ color: lightgray</string>
       <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>

--- a/gui/desktop/option_descriptions.hpp
+++ b/gui/desktop/option_descriptions.hpp
@@ -305,6 +305,10 @@ static std::unordered_map<std::string, std::string> optionDescriptions = {
       "Places hints on the King of Red Lions. Talk to the King of Red Lions to get hints.",
     },
     {
+      "kreeb_bow_hints",
+      "When this option is selected, Kreeb will give an item hint for each Progressive Bow after Link reactivates the Windfall lighthouse.",
+    },
+    {
       "path_hints",
       "Determines the number of path hints that will be placed in the game, distributed using the selected hint placement options.<br>If multiple hint placement options are selected, the hint count will be split evenly among the placement options.",
     },

--- a/gui/wiiu/OptionActions.cpp
+++ b/gui/wiiu/OptionActions.cpp
@@ -352,6 +352,11 @@ namespace OptionCB {
         return fromBool(conf.settings.korl_hints);
     }
 
+    std::string toggleKreebBowHints() {
+        conf.settings.kreeb_bow_hints = !conf.settings.kreeb_bow_hints;
+        return fromBool(conf.settings.kreeb_bow_hints);
+    }
+
     std::string toggleClearHints() {
         conf.settings.clearer_hints = !conf.settings.clearer_hints;
         return fromBool(conf.settings.clearer_hints);
@@ -983,6 +988,8 @@ std::string getValue(const Option& option) {
             return fromBool(conf.settings.ho_ho_triforce_hints);
         case Option::KorlHints:
             return fromBool(conf.settings.korl_hints);
+        case Option::KreebBowHints:
+            return fromBool(conf.settings.kreeb_bow_hints);
         case Option::ClearerHints:
             return fromBool(conf.settings.clearer_hints);
         case Option::UseAlwaysHints:
@@ -1195,6 +1202,8 @@ TriggerCallback getCallback(const Option& option) {
             return &toggleHoHoTriforceHints;
         case Option::KorlHints:
             return &toggleKorlHints;
+        case Option::KreebBowHints:
+            return &toggleKreebBowHints;
         case Option::ClearerHints:
             return &toggleClearHints;
         case Option::UseAlwaysHints:
@@ -1362,6 +1371,7 @@ std::pair<std::string, std::string> getNameDesc(const Option& option) {
         {HoHoHints,                   {"Place Hints on Old Man Ho Ho",        "Places hints on Old Man Ho Ho. Old Man Ho Ho appears at 10 different islands. Simply talk to Old Man Ho Ho to get hints."}},
         {HoHoTriforceHints,           {"Old Man Ho Ho Hints Shards",          "When this option is selected, each Old Man Ho Ho will give an item hint for a Triforce Shard. Hints are not repeated until each shard is hinted once. This setting will override placing other hints on Old Man Ho Ho."}},
         {KorlHints,                   {"Place Hints on King of Red Lions",    "Places hints on the King of Red Lions. Talk to the King of Red Lions to get hints."}},
+        {KreebBowHints,               {"Kreeb Hints Bows",                    "When this option is selected, Kreeb will give an item hint for each Progressive Bow after Link reactivates the Windfall lighthouse."}},
         {ClearerHints,                {"Clearer Hints",                       "When this option is selected, location and item hints will use the standard check or item name, instead of using cryptic hints."}},
         {UseAlwaysHints,              {"Use Always Hints",                    "When the number of location hints is nonzero, certain locations that will always be hinted will take precedence over normal location hints."}},
         {HintImportance,              {"Hint Importance",                     "When this option is selected, item and location hints will also indicate if the hinted item is required, possibly required, or not required. Only progress items will have these additions; non-progress items are trivially not required."}},

--- a/gui/wiiu/OptionActions.hpp
+++ b/gui/wiiu/OptionActions.hpp
@@ -59,6 +59,7 @@ namespace OptionCB {
     std::string toggleHoHoHints();
     std::string toggleHoHoTriforceHints();
     std::string toggleKorlHints();
+    std::string toggleKreebBowHints();
     std::string toggleClearHints();
     std::string toggleAlwaysHints();
     std::string toggleHintImportance();

--- a/gui/wiiu/Page.cpp
+++ b/gui/wiiu/Page.cpp
@@ -270,6 +270,7 @@ HintsPage::HintsPage() {
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::HoHoHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::HoHoTriforceHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::KorlHints));
+    buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::KreebBowHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::ClearerHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::UseAlwaysHints));
     buttonColumns[0].emplace_back(std::make_unique<BasicButton>(Option::HintImportance));

--- a/logic/Hints.cpp
+++ b/logic/Hints.cpp
@@ -724,6 +724,24 @@ static HintError assignHoHoHints(World& world, WorldPool& worlds, std::list<Loca
     return HintError::NONE;
 }
 
+static HintError assignKreebHints(World& world, WorldPool& worlds)
+{
+    // Get all bow locations
+    // Shuffle locations to prevent any possible meta-gaming where the last bow might be
+    // since otherwise they'll appear in order of location id
+    auto allLocations = world.getLocations(/*onlyProgression = */ true);
+    shufflePool(allLocations);
+    for (auto& location : allLocations)
+    {
+        if (location->currentItem.getGameItemId() == GameItem::ProgressiveBow)
+        {
+            world.kreebHints.push_back(location);
+            LOG_AND_RETURN_IF_ERR(generateItemHintMessage(location));
+        }
+    }
+    return HintError::NONE;
+}
+
 HintError generateHints(WorldPool& worlds)
 {
     LOG_AND_RETURN_IF_ERR(calculatePossiblePathLocations(worlds));
@@ -750,6 +768,12 @@ HintError generateHints(WorldPool& worlds)
         uint8_t totalNumHints = settings.path_hints + settings.barren_hints + settings.item_hints + settings.location_hints;
         uint8_t totalMadeHints = hintLocations.size();
         LOG_AND_RETURN_IF_ERR(generateLocationHintLocations(world, hintLocations, totalNumHints - totalMadeHints));
+
+        // Assign Kreeb Bow Hints if the setting is enabled
+        if (settings.kreeb_bow_hints)
+        {
+            assignKreebHints(world, worlds);
+        }
 
         // Distribute hints evenly among the possible hint placement options
         std::vector<std::string> hintPlacementOptions = {};

--- a/logic/LogicTests.cpp
+++ b/logic/LogicTests.cpp
@@ -184,6 +184,7 @@ void runLogicTests(Config& newConfig)
     TEST(settings1, settings1.ho_ho_hints, "5 item hints");
     settings1.location_hints = 5;
     TEST(settings1, settings1.ho_ho_hints, "5 location hints");
+    TEST(settings1, settings1.kreeb_bow_hints, "kreeb bow hints");
     TEST(settings1, settings1.use_always_hints, "use always hints");
     TEST(settings1, settings1.clearer_hints, "clearer hints");
     TEST(settings1, settings1.hint_importance, "hint importance");
@@ -223,6 +224,7 @@ void runLogicTests(Config& newConfig)
     TEST(settings2, settings2.hint_importance, "hint importance");
     TEST(settings2, settings2.clearer_hints, "clearer hints");
     TEST(settings2, settings2.use_always_hints, "use always hints");
+    TEST(settings2, settings2.kreeb_bow_hints, "kreeb bow hints");
     settings2.path_hints = 5;
     TEST(settings2, settings2.korl_hints, "5 path hints");
     settings2.barren_hints = 5;

--- a/logic/SpoilerLog.cpp
+++ b/logic/SpoilerLog.cpp
@@ -238,7 +238,7 @@ void generateSpoilerLog(WorldPool& worlds)
     for (auto& world : worlds)
     {
         // Don't print "Hints" if there are none
-        if (world.hohoHints.empty() && world.korlHints.empty() && world.bigOctoFairyHintLocation == nullptr)
+        if (world.hohoHints.empty() && world.korlHints.empty() && world.bigOctoFairyHintLocation == nullptr && world.kreebHints.empty())
         {
             continue;
         }
@@ -290,6 +290,16 @@ void generateSpoilerLog(WorldPool& worlds)
                 }
             }
             spoilerLog << "        " << Utility::Str::toUTF8(hintText) << std::endl; 
+        }
+
+        if (!world.kreebHints.empty())
+        {
+            spoilerLog << "    Kreeb Hints:" << std::endl;
+            for (auto location : world.kreebHints)
+            {
+                spoilerLog << "        " << getSpoilerFormatHint(location);
+                spoilerLog << std::endl;
+            }
         }
     }
     spoilerLog << std::endl;

--- a/logic/World.hpp
+++ b/logic/World.hpp
@@ -128,6 +128,7 @@ public:
     std::list<Location*> goalLocations = {};
     std::map<std::string, std::unordered_set<Location*>> barrenRegions = {};
     std::list<Location*> korlHints = {};
+    std::list<Location*> kreebHints = {};
     std::map<Location*, std::unordered_set<Location*>, PointerLess<Location>> hohoHints = {}; // map of Ho Ho Hint Location to hinted locations
     Location* bigOctoFairyHintLocation = nullptr;
     std::list<std::list<Location*>> playthroughSpheres = {};

--- a/options.cpp
+++ b/options.cpp
@@ -61,6 +61,7 @@ void Settings::resetDefaultSettings() {
     decouple_entrances = false;
 
     korl_hints = false;
+    kreeb_bow_hints = false;
     ho_ho_hints = false;
     ho_ho_triforce_hints = false;
     path_hints = false;
@@ -237,6 +238,8 @@ uint8_t Settings::getSetting(const Option& option) const {
             return ho_ho_triforce_hints;
         case Option::KorlHints:
             return korl_hints;
+        case Option::KreebBowHints:
+            return kreeb_bow_hints;
         case Option::ClearerHints:
             return clearer_hints;
         case Option::UseAlwaysHints:
@@ -426,6 +429,8 @@ void Settings::setSetting(const Option& option, const size_t& value) {
             ho_ho_triforce_hints = value; return;
         case Option::KorlHints:
             korl_hints = value; return;
+        case Option::KreebBowHints:
+            kreeb_bow_hints = value; return;
         case Option::ClearerHints:
             clearer_hints = value; return;
         case Option::UseAlwaysHints:
@@ -914,6 +919,7 @@ Option nameToSetting(const std::string& name) {
         {"Ho Ho Hints", Option::HoHoHints},
         {"Ho Ho Triforce Hints", Option::HoHoTriforceHints},
         {"Korl Hints", Option::KorlHints},
+        {"Kreeb Bow Hints", Option::KreebBowHints},
         {"Clearer Hints", Option::ClearerHints},
         {"Use Always Hints", Option::UseAlwaysHints},
         {"Hint Importance", Option::HintImportance},
@@ -1016,6 +1022,7 @@ std::string settingToName(const Option& setting) {
         {Option::HoHoHints, "Ho Ho Hints"},
         {Option::HoHoTriforceHints, "Ho Ho Triforce Hints"},
         {Option::KorlHints, "Korl Hints"},
+        {Option::KreebBowHints, "Kreeb Bow Hints"},
         {Option::ClearerHints, "Clearer Hints"},
         {Option::UseAlwaysHints, "Use Always Hints"},
         {Option::HintImportance, "Hint Importance"},

--- a/options.hpp
+++ b/options.hpp
@@ -178,6 +178,7 @@ enum struct Option {
     HoHoHints,
     HoHoTriforceHints,
     KorlHints,
+    KreebBowHints,
     ClearerHints,
     UseAlwaysHints,
     HintImportance,
@@ -269,6 +270,7 @@ public:
     bool ho_ho_hints;
     bool ho_ho_triforce_hints;
     bool korl_hints;
+    bool kreeb_bow_hints;
     bool clearer_hints;
     bool use_always_hints;
     bool hint_importance;

--- a/seedgen/config.cpp
+++ b/seedgen/config.cpp
@@ -196,6 +196,7 @@ ConfigError Config::loadFromFile(const fspath& filePath, const fspath& preferenc
     GET_FIELD(root, "ho_ho_hints", settings.ho_ho_hints)
     GET_FIELD(root, "ho_ho_triforce_hints", settings.ho_ho_triforce_hints)
     GET_FIELD(root, "korl_hints", settings.korl_hints)
+    GET_FIELD(root, "kreeb_bow_hints", settings.kreeb_bow_hints)
     GET_FIELD(root, "clearer_hints", settings.clearer_hints)
     GET_FIELD(root, "use_always_hints", settings.use_always_hints)
     GET_FIELD(root, "hint_importance", settings.hint_importance)
@@ -527,6 +528,7 @@ YAML::Node Config::settingsToYaml() const {
     SET_FIELD(root, "ho_ho_hints", settings.ho_ho_hints)
     SET_FIELD(root, "ho_ho_triforce_hints", settings.ho_ho_triforce_hints)
     SET_FIELD(root, "korl_hints", settings.korl_hints)
+    SET_FIELD(root, "kreeb_bow_hints", settings.kreeb_bow_hints)
     SET_FIELD(root, "clearer_hints", settings.clearer_hints)
     SET_FIELD(root, "use_always_hints", settings.use_always_hints)
     SET_FIELD(root, "hint_importance", settings.hint_importance)
@@ -808,6 +810,7 @@ static const std::vector<Option> PERMALINK_OPTIONS {
     Option::HoHoHints,
     Option::HoHoTriforceHints,
     Option::KorlHints,
+    Option::KreebBowHints,
     Option::PathHints,
     Option::BarrenHints,
     Option::ItemHints,
@@ -902,6 +905,7 @@ static size_t getOptionBitCount(const Option& option) {
         case Option::HoHoHints:
         case Option::HoHoTriforceHints:
         case Option::KorlHints:
+        case Option::KreebBowHints:
         case Option::UseAlwaysHints:
         case Option::ClearerHints:
         case Option::HintImportance:


### PR DESCRIPTION
Adds a hint setting where Kreeb will tell you where all the bows are after you activate the Windfall light house. These hints are not influenced by any other hint types.