### PR TITLE
Hide chart buttons when charts aren't progression

### DIFF
--- a/gui/desktop/tracker/tracker.cpp
+++ b/gui/desktop/tracker/tracker.cpp
@@ -48,6 +48,22 @@ void MainWindow::initialize_tracker_world(Settings& settings,
     // Copy settings to modify them
     trackerSettings = settings;
 
+    // Show or hide chart tracker buttons depending on settings
+    for (auto chartButton : ui->tracker_tab->findChildren<TrackerChartButton*>())
+    {
+        // If charts are randomized, show all charts if either chart progression is enabled
+        if (trackerSettings.randomize_charts)
+        {
+            chartButton->setVisible(trackerSettings.progression_treasure_charts || trackerSettings.progression_triforce_charts);
+        }
+        // If charts aren't randomized, show chart only if their rerespective chart type is progression
+        else
+        {
+            chartButton->setVisible((trackerSettings.progression_treasure_charts && chartButton->isForTreasureChart()) ||
+                                    (trackerSettings.progression_triforce_charts && chartButton->isForTriforceChart()));
+        }
+    }
+
     selectedChartIsland = 0;
     if (settings.randomize_charts)
     {

--- a/gui/desktop/tracker/tracker_inventory_button.cpp
+++ b/gui/desktop/tracker/tracker_inventory_button.cpp
@@ -165,7 +165,7 @@ void TrackerChartButton::updateIcon()
     std::string chartState = "treasure_chart_closed.png";
     if(mainWindow->trackerSettings.randomize_charts) {
         if(const GameItem chart = mainWindow->chartForIsland(islandNum); chart != GameItem::INVALID) {
-            if(chart == GameItem::TriforceChart1 || chart == GameItem::TriforceChart2 || chart == GameItem::TriforceChart3) {
+            if(this->isForTriforceChart()) {
                 chartState = "triforce_chart_open.png";
             }
             else {
@@ -174,7 +174,7 @@ void TrackerChartButton::updateIcon()
         }
     }
     else if(const GameItem chart = roomNumToDefaultChart(islandNum); elementInPool(Item(chart, &mainWindow->trackerWorlds[0]), mainWindow->trackerInventory)) {
-        if(chart == GameItem::TriforceChart1 || chart == GameItem::TriforceChart2 || chart == GameItem::TriforceChart3) {
+        if(this->isForTriforceChart()) {
             chartState = "triforce_chart_open.png";
         }
         else {
@@ -182,7 +182,7 @@ void TrackerChartButton::updateIcon()
         }
     }
     else {
-        if(chart == GameItem::TriforceChart1 || chart == GameItem::TriforceChart2 || chart == GameItem::TriforceChart3) {
+        if(this->isForTriforceChart()) {
             chartState = "triforce_chart_closed.png";
         }
     }
@@ -190,6 +190,17 @@ void TrackerChartButton::updateIcon()
     setStyleSheet("background-image: url(" + getTrackerAssetPath(chartState) + ");"
                 + "background-repeat: none;"
                 + "background-position: center;");
+}
+
+bool TrackerChartButton::isForTriforceChart() const
+{
+    const GameItem chart = roomNumToDefaultChart(islandNum);
+    return chart == GameItem::TriforceChart1 || chart == GameItem::TriforceChart2 || chart == GameItem::TriforceChart3;
+}
+
+bool TrackerChartButton::isForTreasureChart() const
+{
+    return !isForTriforceChart();
 }
 
 void TrackerChartButton::mouseReleaseEvent(QMouseEvent* e)

--- a/gui/desktop/tracker/tracker_inventory_button.hpp
+++ b/gui/desktop/tracker/tracker_inventory_button.hpp
@@ -67,6 +67,8 @@ public:
     QPoint mouseEnterPosition = QPoint();
 
     void updateIcon();
+    bool isForTriforceChart() const;
+    bool isForTreasureChart() const;
 
 signals:
     void chart_map_button_pressed(uint8_t islandNum);


### PR DESCRIPTION
Chart buttons will now be hidden if their corresponding chart types can't lead to progression items. The View Charts button will still show and allow for users to mark which charts they have if they find them.