### PR TITLE
Fix console crash when entering final staircase

### DIFF
--- a/asm/patch_diffs/required_bosses_diff.yaml
+++ b/asm/patch_diffs/required_bosses_diff.yaml
@@ -20,3 +20,5 @@ Relocations:
 - {r_addend: 0x8FAE4C, r_info: 0x104, r_offset: 0x28FAE7E}
 - {r_addend: 0x8FAE44, r_info: 0x106, r_offset: 0x28FAEAA}
 - {r_addend: 0x8FAE44, r_info: 0x104, r_offset: 0x28FAEAE}
+- {r_addend: 0x1F84DC, r_info: 0x206, r_offset: 0x28FAED6}
+- {r_addend: 0x1F84DC, r_info: 0x204, r_offset: 0x28FAEDA}

--- a/asm/patches/required_bosses.asm
+++ b/asm/patches/required_bosses.asm
@@ -67,8 +67,8 @@ check_required_bosses_check_continue_loop:
   bne+ check_required_bosses_begin_loop
 
 ; If all required bosses are defeated, set the associated switch flag (0x25)
-  lis r3, 0x1020
-  lwz r3, -0x7b24(r3)
+  lis r3, gameInfo_ptr@ha
+  lwz r3, gameInfo_ptr@l(r3)
   addi r3, r3, 0x20 ; SaveData->mCurInfo
   li r4, 0x25 ; flag
   li r5, 0 ; current room number (which is 0)


### PR DESCRIPTION
I accidentally left in a hardcoded address that should've been a symbol oops. This meant that things worked fine on emulator, but crashed on console.