### PR TITLE
Show Charts Option

### DIFF
--- a/gui/desktop/mainwindow.hpp
+++ b/gui/desktop/mainwindow.hpp
@@ -137,6 +137,7 @@ public:
     bool isIslandMappedToChart(uint8_t island);
     uint8_t islandForChart(GameItem chart);
     GameItem chartForIsland(uint8_t islandNum);
+    void tracker_update_chart_visibility();
 
 private slots:
     void show_error_dialog(const std::string& s, const std::string& title = "An error has occured!");

--- a/gui/desktop/tracker/tracker_preferences.hpp
+++ b/gui/desktop/tracker/tracker_preferences.hpp
@@ -10,6 +10,7 @@ struct TrackerPreferences {
     bool showNonProgressLocations = false;
     bool rightClickClearAll = true;
     bool clearAllIncludesDependentLocations = true;
+    bool showCharts = true;
     bool overrideItemsColor = false;
     bool overrideLocationsColor = false;
     bool overrideStatsColor = false;

--- a/gui/desktop/tracker/tracker_preferences_dialog.cpp
+++ b/gui/desktop/tracker/tracker_preferences_dialog.cpp
@@ -12,6 +12,11 @@ TrackerPreferencesDialog::TrackerPreferencesDialog(MainWindow* main_) : main(mai
     ui.show_nonprogress_locations->setChecked(main->trackerPreferences.showNonProgressLocations);
     ui.right_click_to_clear_all->setChecked(main->trackerPreferences.rightClickClearAll);
     ui.clear_all_includes_dependent_locations->setChecked(main->trackerPreferences.clearAllIncludesDependentLocations);
+    ui.show_charts->setChecked(main->trackerPreferences.showCharts);
+    if(main->trackerSettings.randomize_charts && (main->trackerSettings.progression_triforce_charts || main->trackerSettings.progression_treasure_charts)) {
+        ui.show_charts->setChecked(true);
+        ui.show_charts->setEnabled(false);
+    }
     ui.override_items_background_color->setChecked(main->trackerPreferences.overrideItemsColor);
     ui.override_locations_background_color->setChecked(main->trackerPreferences.overrideLocationsColor);
     ui.override_statistics_background_color->setChecked(main->trackerPreferences.overrideStatsColor);
@@ -61,6 +66,13 @@ void TrackerPreferencesDialog::on_right_click_to_clear_all_stateChanged(int arg1
 void TrackerPreferencesDialog::on_clear_all_includes_dependent_locations_stateChanged(int arg1)
 {
     main->trackerPreferences.clearAllIncludesDependentLocations = arg1;
+}
+
+
+void TrackerPreferencesDialog::on_show_charts_stateChanged(int arg1)
+{
+    main->trackerPreferences.showCharts = arg1;
+    main->tracker_update_chart_visibility();
 }
 
 

--- a/gui/desktop/tracker/tracker_preferences_dialog.hpp
+++ b/gui/desktop/tracker/tracker_preferences_dialog.hpp
@@ -17,6 +17,7 @@ private slots:
     void on_show_nonprogress_locations_stateChanged(int arg1);
     void on_right_click_to_clear_all_stateChanged(int arg1);
     void on_clear_all_includes_dependent_locations_stateChanged(int arg1);
+    void on_show_charts_stateChanged(int arg1);
     void on_override_items_background_color_stateChanged(int arg1);
     void on_override_locations_background_color_stateChanged(int arg1);
     void on_override_statistics_background_color_stateChanged(int arg1);

--- a/gui/desktop/tracker/tracker_preferences_dialog.ui
+++ b/gui/desktop/tracker/tracker_preferences_dialog.ui
@@ -89,6 +89,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="show_charts">
+     <property name="text">
+      <string>Show Charts</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>6</number>


### PR DESCRIPTION
Adds a tracker preference to show/hide charts on the map. Charts will still be shown if they can contain progress items. If charts are randomized and any type is progress, the preference is forced to show charts.