### PR TITLE
Fix some entrances not getting properly evaluated in the tracker

### DIFF
--- a/gui/desktop/tracker/tracker.cpp
+++ b/gui/desktop/tracker/tracker.cpp
@@ -1046,7 +1046,7 @@ void MainWindow::check_special_accessibility_conditions()
 
 void MainWindow::update_tracker_areas_and_autosave()
 {
-    getAccessibleLocations(trackerWorlds, trackerInventory, trackerLocations);
+    getAccessibleLocations(trackerWorlds, trackerInventory, trackerLocations, -1, true);
     check_special_accessibility_conditions();
 
     // Apply any own dungeon items after we get the accessible locations
@@ -1078,7 +1078,7 @@ void MainWindow::update_tracker_areas_and_autosave()
 
         if (addedItems)
         {
-            getAccessibleLocations(trackerWorlds, trackerInventoryExtras, trackerLocations);
+            getAccessibleLocations(trackerWorlds, trackerInventoryExtras, trackerLocations, -1, true);
             check_special_accessibility_conditions();
         }
     }
@@ -1666,7 +1666,7 @@ void MainWindow::calculate_own_dungeon_key_locations()
         }
 
         // Find all possible locations for this key in the dungeon
-        auto accessibleLocations = getAccessibleLocations(trackerWorlds, itemPool, trackerLocations);
+        auto accessibleLocations = getAccessibleLocations(trackerWorlds, itemPool, trackerLocations, -1, true);
         auto potentialKeyLocations = filterFromPool(accessibleLocations, [&](Location* loc){return loc->getName().starts_with(dungeonName);});
 
         // Save the possible locations for this key

--- a/logic/Search.hpp
+++ b/logic/Search.hpp
@@ -12,8 +12,8 @@ enum struct SearchMode
     GeneratePlaythrough,
 };
 
-LocationPool search(const SearchMode& searchMode, WorldPool& worlds, ItemPool items, int worldToSearch = -1);
-LocationPool getAccessibleLocations(WorldPool& worlds, ItemPool& items, LocationPool& allowedLocations, int worldToSearch = -1);
+LocationPool search(const SearchMode& searchMode, WorldPool& worlds, ItemPool items, int worldToSearch = -1, bool tracker = false);
+LocationPool getAccessibleLocations(WorldPool& worlds, ItemPool& items, LocationPool& allowedLocations, int worldToSearch = -1, bool tracker = false);
 void runGeneralSearch(WorldPool& worlds, int worldToSearch = -1);
 bool gameBeatable(WorldPool& worlds);
 void generatePlaythrough(WorldPool& worlds);


### PR DESCRIPTION
Entrances which haven't been connected were generally being ignored by the search code, since normally there'd be no reason to check them. However the tracker needs to show these entrances as accessible even if they don't lead anywhere, so now if the search code is being used for the tracker, it will include these entrances for evaluation.