### PR TITLE
Add ARM MacOS Builds to Actions

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -11,8 +11,8 @@ jobs:
   build-wiiu:
     uses: ./.github/workflows/build_wiiu.yml
 
-  build-mac:
-    uses: ./.github/workflows/build_mac.yml
+  build-mac-x64:
+    uses: ./.github/workflows/build_mac_x64.yml
 
   build-mac-arm:
     uses: ./.github/workflows/build_mac_arm.yml

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -13,3 +13,6 @@ jobs:
 
   build-mac:
     uses: ./.github/workflows/build_mac.yml
+
+  build-mac-arm:
+    uses: ./.github/workflows/build_mac_arm.yml

--- a/.github/workflows/build_mac_arm.yml
+++ b/.github/workflows/build_mac_arm.yml
@@ -1,0 +1,97 @@
+name: Build - Mac (ARM)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'Build Type'
+        default: "Debug"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version'
+        default: ''
+        required: false
+        type: string
+      build_type:
+        description: 'Build Type'
+        default: "Debug"
+        required: false
+        type: string
+    secrets:
+      SEED_KEY:
+        description: 'Key used to complicate the seed string in release builds'
+        required: false
+
+env:
+  QT_VERSION: 6.10.1
+  EXTRA_CMAKE_FLAGS: ""
+
+jobs:
+  build-desktop-application-mac-arm:
+    name: Build Desktop Application Mac (ARM)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '${{ env.QT_VERSION }}'
+          host: 'mac'
+          target: 'desktop'
+          arch: 'clang_64'
+          cache: true
+
+      - name: Set Debug Flags
+        if: inputs.build_type == 'Debug'
+        run: echo "EXTRA_CMAKE_FLAGS=-DENABLE_DEBUG=True ${{ env.EXTRA_CMAKE_FLAGS }}" >> $GITHUB_ENV
+
+      - name: Set Release Flags
+        if: inputs.build_type == 'Release' && inputs.version != ''
+        run: echo "EXTRA_CMAKE_FLAGS=-DRELEASE_TAG=${{ inputs.version }} ${{ env.EXTRA_CMAKE_FLAGS }}" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        working-directory: ${{ github.workspace }}
+        env:
+          SEED_KEY: ${{ secrets.SEED_KEY }}
+        run: cmake -B build -DGITHUB_WORKFLOW=True -DQT_GUI=True -DEMBED_DATA=True "${{ env.EXTRA_CMAKE_FLAGS }}"
+
+      - name: Build
+        working-directory: ${{ github.workspace }}
+        run: cmake --build build --config ${{ inputs.build_type }} -j
+
+      - name: Call macdeployqt
+        working-directory: ${{ github.workspace }}/build
+        run: ../../Qt/${{ env.QT_VERSION }}/macos/bin/macdeployqt wwhd_rando.app
+
+      - name: Create DMG
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          mkdir dmg_contents
+          cp ../gui/desktop/mac_user_instructions.txt ./dmg_contents/READ_THIS_FIRST.txt
+          cp -R wwhd_rando.app ./dmg_contents/wwhd_rando.app
+          echo killing...; sudo pkill -9 XProtect >/dev/null || true;
+          echo waiting...; while pgrep XProtect; do sleep 3; done;
+          hdiutil create -srcfolder ./dmg_contents wwhd_rando
+
+      - name: Get Version
+        id: get-version
+        shell: pwsh
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+
+      - name: Save Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          path: ${{github.workspace}}/build/wwhd_rando.dmg
+          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_arm.dmg

--- a/.github/workflows/build_mac_x64.yml
+++ b/.github/workflows/build_mac_x64.yml
@@ -1,4 +1,4 @@
-name: Build - Mac
+name: Build - Mac (x64)
 
 on:
   workflow_dispatch:
@@ -30,8 +30,8 @@ env:
   EXTRA_CMAKE_FLAGS: ""
 
 jobs:
-  build-desktop-application-mac:
-    name: Build Desktop Application Mac
+  build-desktop-application-mac-x64:
+    name: Build Desktop Application Mac (x64)
     runs-on: macos-15-intel
 
     steps:
@@ -94,4 +94,4 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           path: ${{github.workspace}}/build/wwhd_rando.dmg
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac.dmg
+          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_x64.dmg

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -21,8 +21,16 @@ jobs:
     secrets:
       SEED_KEY: ${{ secrets.SEED_KEY }}
   
-  build-mac:
-    uses: ./.github/workflows/build_mac.yml
+  build-mac-x64:
+    uses: ./.github/workflows/build_mac_x64.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+      build_type: Release
+    secrets:
+      SEED_KEY: ${{ secrets.SEED_KEY }}
+  
+  build-mac-arm:
+    uses: ./.github/workflows/build_mac_arm.yml
     with:
       version: ${{ github.event.release.tag_name }}
       build_type: Release
@@ -31,7 +39,7 @@ jobs:
 
   attach-to-release:
     name: Attach To Release
-    needs: [build-windows, build-wiiu, build-mac]
+    needs: [build-windows, build-wiiu, build-mac-x64, build-mac-arm]
     runs-on: ubuntu-latest
  
     steps:
@@ -53,10 +61,15 @@ jobs:
        with:
         name: wwhd_rando_${{ github.event.release.tag_name }}.wuhb # pass name so it doesn't get put in a folder
     
-     - name: Download Mac OS Artifact
+     - name: Download Mac OS Artifact (x64)
        uses: actions/download-artifact@v7
        with:
-        name: wwhd_rando_${{ github.event.release.tag_name }}_mac.dmg # pass name so it doesn't get put in a folder
+        name: wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg # pass name so it doesn't get put in a folder
+    
+     - name: Download Mac OS Artifact (ARM)
+       uses: actions/download-artifact@v7
+       with:
+        name: wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg # pass name so it doesn't get put in a folder
 
      - name: Zip windows file
        uses: montudor/action-zip@v1
@@ -69,4 +82,4 @@ jobs:
        run: |
          ls -R
          mv wwhd_rando.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac.dmg
-         gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac.dmg
+         gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg


### PR DESCRIPTION
Adds a native ARM build for Macs with Apple Silicon. Was able to test briefly and it didn't seem to have major issues, but I am not able to exhaustively test these builds. Resolves #166.