### PR TITLE
Improve Artifact Handling

### DIFF
--- a/.github/workflows/build_linux_x64.yml
+++ b/.github/workflows/build_linux_x64.yml
@@ -92,10 +92,14 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: |
           echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+      
+      - name: Rename Artifact
+        working-directory: ${{ github.workspace }}
+        run: |
+          mv The_Wind_Waker_HD_Randomizer-x86_64.AppImage wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64.AppImage
 
       - name: Save Artifact
         uses: actions/upload-artifact@v7
         with:
-          path: ${{github.workspace}}/The_Wind_Waker_HD_Randomizer-x86_64.AppImage
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64.AppImage
+          path: ${{github.workspace}}/wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64.AppImage
           archive: false

--- a/.github/workflows/build_linux_x64.yml
+++ b/.github/workflows/build_linux_x64.yml
@@ -97,4 +97,4 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           path: ${{github.workspace}}/The_Wind_Waker_HD_Randomizer-x86_64.AppImage
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64
+          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64.AppImage

--- a/.github/workflows/build_linux_x64.yml
+++ b/.github/workflows/build_linux_x64.yml
@@ -94,7 +94,8 @@ jobs:
           echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
 
       - name: Save Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/The_Wind_Waker_HD_Randomizer-x86_64.AppImage
           name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_linux_x64.AppImage
+          archive: false

--- a/.github/workflows/build_mac_arm.yml
+++ b/.github/workflows/build_mac_arm.yml
@@ -91,7 +91,8 @@ jobs:
           echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
 
       - name: Save Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/build/wwhd_rando.dmg
           name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_arm.dmg
+          archive: false

--- a/.github/workflows/build_mac_arm.yml
+++ b/.github/workflows/build_mac_arm.yml
@@ -73,6 +73,13 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: ../../Qt/${{ env.QT_VERSION }}/macos/bin/macdeployqt wwhd_rando.app
 
+      - name: Get Version
+        id: get-version
+        shell: pwsh
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+
       - name: Create DMG
         working-directory: ${{ github.workspace }}/build
         run: |
@@ -81,18 +88,10 @@ jobs:
           cp -R wwhd_rando.app ./dmg_contents/wwhd_rando.app
           echo killing...; sudo pkill -9 XProtect >/dev/null || true;
           echo waiting...; while pgrep XProtect; do sleep 3; done;
-          hdiutil create -srcfolder ./dmg_contents wwhd_rando
-
-      - name: Get Version
-        id: get-version
-        shell: pwsh
-        working-directory: ${{ github.workspace }}/build
-        run: |
-          echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+          hdiutil create -srcfolder ./dmg_contents wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_arm.dmg
 
       - name: Save Artifact
         uses: actions/upload-artifact@v7
         with:
-          path: ${{github.workspace}}/build/wwhd_rando.dmg
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_arm.dmg
+          path: ${{github.workspace}}/build/wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_arm.dmg
           archive: false

--- a/.github/workflows/build_mac_x64.yml
+++ b/.github/workflows/build_mac_x64.yml
@@ -91,7 +91,8 @@ jobs:
           echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
 
       - name: Save Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/build/wwhd_rando.dmg
           name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_x64.dmg
+          archive: false

--- a/.github/workflows/build_mac_x64.yml
+++ b/.github/workflows/build_mac_x64.yml
@@ -73,6 +73,13 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         run: ../../Qt/${{ env.QT_VERSION }}/macos/bin/macdeployqt wwhd_rando.app
 
+      - name: Get Version
+        id: get-version
+        shell: pwsh
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+
       - name: Create DMG
         working-directory: ${{ github.workspace }}/build
         run: |
@@ -81,18 +88,10 @@ jobs:
           cp -R wwhd_rando.app ./dmg_contents/wwhd_rando.app
           echo killing...; sudo pkill -9 XProtect >/dev/null || true;
           echo waiting...; while pgrep XProtect; do sleep 3; done;
-          hdiutil create -srcfolder ./dmg_contents wwhd_rando
-
-      - name: Get Version
-        id: get-version
-        shell: pwsh
-        working-directory: ${{ github.workspace }}/build
-        run: |
-          echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
+          hdiutil create -srcfolder ./dmg_contents wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_x64.dmg
 
       - name: Save Artifact
         uses: actions/upload-artifact@v7
         with:
-          path: ${{github.workspace}}/build/wwhd_rando.dmg
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_x64.dmg
+          path: ${{github.workspace}}/build/wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_mac_x64.dmg
           archive: false

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -82,7 +82,7 @@ jobs:
      - name: Download Linux Artifact (x64)
        uses: actions/download-artifact@v7
        with:
-        name: wwhd_rando_${{ github.event.release.tag_name }}_linux_x64 # pass name so it doesn't get put in a folder
+        name: wwhd_rando_${{ github.event.release.tag_name }}_linux_x64.AppImage # pass name so it doesn't get put in a folder
 
      - name: Zip windows file
        uses: montudor/action-zip@v1

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -55,39 +55,31 @@ jobs:
      - name: Checkout Repository
        uses: actions/checkout@v6
 
-     - name: Create Folder for Windows Files
-       run: mkdir wwhd_rando_${{ github.event.release.tag_name }}_windows
-
      - name: Download Windows Artifact
-       uses: actions/download-artifact@v7
+       uses: actions/download-artifact@v8
        with:
-        path: ${{ github.workspace }}/wwhd_rando_${{ github.event.release.tag_name }}_windows
-        name: wwhd_rando_${{ github.event.release.tag_name }}_windows # pass name so it doesn't get put in a folder
+        name: wwhd_rando_${{ github.event.release.tag_name }}_windows.zip # pass name so it doesn't get put in a folder
+        skip-decompress: true
 
      - name: Download Wii U Artifact
-       uses: actions/download-artifact@v7
+       uses: actions/download-artifact@v8
        with:
         name: wwhd_rando_${{ github.event.release.tag_name }}.wuhb # pass name so it doesn't get put in a folder
     
      - name: Download Mac OS Artifact (x64)
-       uses: actions/download-artifact@v7
+       uses: actions/download-artifact@v8
        with:
         name: wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg # pass name so it doesn't get put in a folder
     
      - name: Download Mac OS Artifact (ARM)
-       uses: actions/download-artifact@v7
+       uses: actions/download-artifact@v8
        with:
         name: wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg # pass name so it doesn't get put in a folder
     
      - name: Download Linux Artifact (x64)
-       uses: actions/download-artifact@v7
+       uses: actions/download-artifact@v8
        with:
         name: wwhd_rando_${{ github.event.release.tag_name }}_linux_x64.AppImage # pass name so it doesn't get put in a folder
-
-     - name: Zip windows file
-       uses: montudor/action-zip@v1
-       with:
-         args: zip -qq -r wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando_${{ github.event.release.tag_name }}_windows
 
      - name: Attach Files
        env:
@@ -95,4 +87,4 @@ jobs:
        run: |
          ls -R
          mv wwhd_rando.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac.dmg
-         gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg
+         gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg wwhd_rando_${{ github.event.release.tag_name }}_linux_x64.AppImage

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -84,7 +84,4 @@ jobs:
      - name: Attach Files
        env:
         GITHUB_TOKEN: ${{ github.TOKEN }}
-       run: |
-         ls -R
-         mv wwhd_rando.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac.dmg
-         gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg wwhd_rando_${{ github.event.release.tag_name }}_linux_x64.AppImage
+       run: gh release upload ${{ github.event.release.tag_name }} wwhd_rando_${{ github.event.release.tag_name }}_windows.zip wwhd_rando.wuhb wwhd_rando_${{ github.event.release.tag_name }}_mac_x64.dmg wwhd_rando_${{ github.event.release.tag_name }}_mac_arm.dmg wwhd_rando_${{ github.event.release.tag_name }}_linux_x64.AppImage

--- a/.github/workflows/build_wiiu.yml
+++ b/.github/workflows/build_wiiu.yml
@@ -66,5 +66,4 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/build/wwhd_rando.wuhb
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}.wuhb
           archive: false

--- a/.github/workflows/build_wiiu.yml
+++ b/.github/workflows/build_wiiu.yml
@@ -63,7 +63,8 @@ jobs:
           echo "RANDO_VERSION=$(((Get-Content version.hpp | Select-String -Pattern '#define RANDOMIZER_VERSION "[0-9\.\-a-z]*"') -Replace '.*("[0-9\.\-a-z]*").*', '$1') -Replace '"', '')" >> $env:GITHUB_OUTPUT
 
       - name: Save Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/build/wwhd_rando.wuhb
           name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}.wuhb
+          archive: false

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -101,7 +101,8 @@ jobs:
           ${{ github.workspace }}\..\Qt\${{ env.QT_VERSION }}\mingw_64\bin\qtenv2.bat && cd ${{ github.workspace }}\build\wwhd_rando_windows && windeployqt wwhd_rando.exe --no-translations --no-system-d3d-compiler --no-opengl-sw
 
       - name: Save Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           path: ${{github.workspace}}/build/wwhd_rando_windows
-          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_windows
+          name: wwhd_rando_${{ steps.get-version.outputs.RANDO_VERSION }}_windows.zip
+          archive: true

--- a/main.cpp
+++ b/main.cpp
@@ -43,6 +43,9 @@ int main(int argc, char *argv[]) {
     #endif
 
     QApplication::setStyle("Fusion");
+    #ifdef __linux__
+        QApplication::setApplicationName("TWWHD Randomizer");
+    #endif
 
     QApplication a(argc, argv);
     QApplication::setPalette(getColorPalette());


### PR DESCRIPTION
- Upload artifact files directly when possible instead of zipping
- Simplify handling of the Windows zip
- Use a more consistent data folder on Linux (no longer depends on the AppImage name)