### PR TITLE
Properly Set Unrequired Bosses in Entrance Rando

### DIFF
--- a/logic/World.cpp
+++ b/logic/World.cpp
@@ -538,6 +538,7 @@ World::WorldLoadingError World::determineRequiredDungeons(WorldPool& worlds)
                     // manually add it to the non-progress checks
                     if (!dungeon.hasNaturalBossLocation)
                     {
+                        dungeon.bossLocation->progression = false;
                         nonProgressRollbacks.push_back(dungeon.bossLocation);
                     }
 


### PR DESCRIPTION
Fixes an issue with mixed entrance pools where unrequired bosses not directly connected to a dungeon wouldn't be marked nonprogress in race mode