### PR TITLE
Old Man Ho Ho hint generation oddity

### DIFF
--- a/logic/Hints.cpp
+++ b/logic/Hints.cpp
@@ -863,6 +863,10 @@ HintError generateHints(WorldPool& worlds)
         size_t i = 0;
         for (auto& hint : hints)
         {
+            // this can happen if we've avoided korl hints earlier but we had ho ho triforce hints on
+            // assignHoHoHints generate the triforce hints anyway so breaking out of that loop is not a big deal
+            if(hintPlacementOptions.empty()) break;
+
             // iterate to the next placement option on each index of the hint locations
             std::string placementOption = hintPlacementOptions[i % hintPlacementOptions.size()];
             // add the hint location to that placement option


### PR DESCRIPTION
Re: https://discord.com/channels/838818094151499816/1545898986848911391
If korl hints are avoided and ho ho triforce hints are on then when generating hints, we end up with an empty `hintsPlacementOptions` map and we try to read into it. break out of the loop if this happens